### PR TITLE
poc: surface package IDs as frontmatter on olympus checkout

### DIFF
--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -40,11 +40,11 @@
     - bundle-selector (the "main" cart that this bump augments)
     - cart-summary (will list the bump as an additional line)
 {% endcomment %}
-{% assign pkg_id = package_id | default: 7 -%}
+{% assign pkg_id = package_id | default: packages.prepurchase_1 | default: 7 -%}
 {% assign t = title | default: 'Get Extended Warranty' -%}
 {% assign img_src = bump_image | default: 'images/1x1_1.svg' -%}
 {% assign img_alt = bump_image_alt | default: t -%}
-{% if package_sync == nil %}{% assign package_sync = 1 %}{% endif -%}
+{% if package_sync == nil %}{% assign package_sync = packages.main_package | default: 1 %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = true %}{% endif -%}

--- a/src/olympus/_includes/bump-switch01.html
+++ b/src/olympus/_includes/bump-switch01.html
@@ -25,12 +25,13 @@
     - bundle-selector (the main cart this bump augments)
     - cart-summary (will list the bump as an additional line)
 {% endcomment %}
+{% assign _switch_pkg = packages.prepurchase_2 | default: 9 -%}
 <!-- Prepurchase upsell: toggle-switch bump (switch01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      No data-next-package-sync: one line item, not per main-unit (contrast bump-check01). -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>
-    <div class="bump-card bump-card--switch" data-next-toggle-card data-next-is-upsell="true" data-next-package-id="9">
+    <div class="bump-card bump-card--switch" data-next-toggle-card data-next-is-upsell="true" data-next-package-id="{{ _switch_pkg }}">
       <div class="bump__header-left bump__head--switch">
         <div class="bump__header-content bump__head-inner">
           <span class="bump__title">Shipping Insurance &amp; Loss Prevention</span>

--- a/src/olympus/_includes/bundle-selector.html
+++ b/src/olympus/_includes/bundle-selector.html
@@ -124,11 +124,12 @@
     </div>
     {% endfor -%}
     {% else -%}
-    {%- comment -%} Default: canonical 3-tier (1x/2x/3x of package_id 1). Override by passing `bundles=[...]`. {%- endcomment -%}
-    <div data-next-bundle-card data-next-bundle-id="drone-qty-1" data-next-shipping-id="2" data-next-bundle-items='[{"packageId":1,"quantity":1}]' data-next-selected="true" role="button" class="os-card">
+    {%- comment -%} Default: canonical 3-tier (1x/2x/3x). Package ID from packages.main_package param or fallback 1. Override cards entirely by passing `bundles=[...]`. {%- endcomment -%}
+    {%- assign _pkg = packages.main_package | default: 1 -%}
+    <div data-next-bundle-card data-next-bundle-id="drone-qty-1" data-next-shipping-id="2" data-next-bundle-items='[{"packageId":{{ _pkg }},"quantity":1}]' data-next-selected="true" role="button" class="os-card">
       <div class="os-card__header-slot"></div>
       <div class="os-card__wrapper">
-        <div class="os-card__content os--align-middle" data-next-package-id="1">
+        <div class="os-card__content os--align-middle" data-next-package-id="{{ _pkg }}">
           <div data-selected="true" class="radio-style-1">
             <div class="radio-inner"></div>
           </div>
@@ -170,10 +171,10 @@
         </div>
       </div>
     </div>
-    <div data-next-bundle-card data-next-bundle-id="drone-qty-2" data-next-shipping-id="2" data-next-bundle-items='[{"packageId":1,"quantity":2}]' role="button" class="os-card">
+    <div data-next-bundle-card data-next-bundle-id="drone-qty-2" data-next-shipping-id="2" data-next-bundle-items='[{"packageId":{{ _pkg }},"quantity":2}]' role="button" class="os-card">
       <div class="os-card__header-slot"></div>
       <div class="os-card__wrapper">
-        <div class="os-card__content os--align-middle" data-next-package-id="1">
+        <div class="os-card__content os--align-middle" data-next-package-id="{{ _pkg }}">
           <div class="radio-style-1">
             <div class="radio-inner"></div>
           </div>
@@ -215,10 +216,10 @@
         </div>
       </div>
     </div>
-    <div data-next-bundle-card data-next-bundle-id="drone-qty-3" data-next-shipping-id="1" data-next-bundle-items='[{"packageId":1,"quantity":3}]' role="button" class="os-card">
+    <div data-next-bundle-card data-next-bundle-id="drone-qty-3" data-next-shipping-id="1" data-next-bundle-items='[{"packageId":{{ _pkg }},"quantity":3}]' role="button" class="os-card">
       <div class="os-card__header-slot"></div>
       <div class="os-card__wrapper">
-        <div class="os-card__content os--align-middle" data-next-package-id="1">
+        <div class="os-card__content os--align-middle" data-next-package-id="{{ _pkg }}">
           <div class="radio-style-1">
             <div class="radio-inner"></div>
           </div>

--- a/src/olympus/checkout.html
+++ b/src/olympus/checkout.html
@@ -37,6 +37,10 @@ swiper_thumbs:
     alt: ""
   - src: "images/1x1_2.svg"
     alt: ""
+packages:
+  main_package: 1
+  prepurchase_1: 7
+  prepurchase_2: 9
 ---
 <div class="page-wrapper">
       <div class="main-wrapper">
@@ -209,7 +213,7 @@ swiper_thumbs:
                               <h2 class="form-section__title">Step 1: Pick Your Bundle Deal</h2>
                               <!-- v0 catalog: bundle-selector partial. Canonical 3-tier defaults (1x/2x/3x package_id 1) embedded in partial; pass `bundles=[...]` to override.
                                    Reference variant (data-next-bundles= JSON config-driven) preserved below as commented reference. -->
-                              {% campaign_include 'bundle-selector.html' selector_id='drone-packages' %}
+                              {% campaign_include 'bundle-selector.html' selector_id='drone-packages' packages=packages %}
                               {% comment %}
                               Reference only — optional config-driven variant.
                               Kept for experimentation; do not treat as the default for Olympus checkout.
@@ -279,8 +283,8 @@ swiper_thumbs:
                               {% campaign_include 'customer-info-form.html' %}
                               {% campaign_include 'shipping-address-form.html' %}
                             </div>
-                        {% campaign_include 'bump-check01.html' %}
-                        {% campaign_include 'bump-switch01.html' %}
+                        {% campaign_include 'bump-check01.html' packages=packages %}
+                        {% campaign_include 'bump-switch01.html' packages=packages %}
                             <div class="form-section form-section--last">
                               <div class="form-section__header">
                                 <h1 class="form-section__title">4. Payment Method</h1>


### PR DESCRIPTION
Adds packages: frontmatter block to olympus/checkout.html with three keys:
  main_package, prepurchase_1, prepurchase_2

Passes packages=packages to bundle-selector, bump-check01, and bump-switch01 at their campaign_include call sites. Each partial falls back to its existing hardcoded default when no packages object is provided — fully backwards-compat.

Proves the CPK build tool already supports passing frontmatter objects into partials (same mechanism as swiper_slides/swiper_thumbs). A developer setting up a new campaign now only edits the frontmatter block — no hunting through partial HTML for scattered data-next-package-id attributes.

Build: 49 pages, 0 errors. lint:sdk PASS.