### PR TITLE
docs: sync with next-campaign-page-kit 0.1.1 changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,19 @@ Note: when copying a template, the developer renames the folder to their product
 ## campaigns.json
 - **Project-level, not template-specific** — accumulates all campaigns a developer adds
 - `_data/campaigns.json` is a reference file showing full field structure for all current templates
-- Fields: `name`, `slug`, `description`, `sdk_version`, `store_name`, `store_url`, `store_terms`, `store_privacy`, `store_contact`, `store_returns`, `store_shipping`, `store_phone`, `store_phone_tel`; optional layout analytics: `gtm_id`, `fb_pixel_id` (see `docs/campaign-page-kit-template-context.md`)
+- **Format:** keyed by slug — `{ "my-campaign": { "name": "...", ... } }` (not the old array format `{ "campaigns": [...] }`)
+- Fields: `name`, `description`, `entry_url`, `sdk_version`, `store_name`, `store_url`, `store_terms`, `store_privacy`, `store_contact`, `store_returns`, `store_shipping`, `store_phone`, `store_phone_tel`; optional layout analytics: `gtm_id`, `fb_pixel_id` (see `docs/campaign-page-kit-template-context.md`)
+- `entry_url` — optional; the page slug `npm run dev` opens (e.g. `"presell"`)
 - slug drives URL: `campaign-domain.com/[slug]/page`
 
-## npm run build behaviour
-- Builds ALL campaigns in `src/` to `_site/`
-- `npm run dev` is interactive — lets you pick ONE campaign to preview
+## npm scripts
+- `npm run dev` — interactive campaign picker + dev server (picks ONE campaign to preview)
+- `npm run build` — builds ALL campaigns in `src/` to `_site/`
+- `npm run start` — interactive launcher menu (dev / compress / clone / config)
+- `npm run clone` — duplicate a campaign to a new slug
+- `npm run config` — set API key for a campaign
+- `npm run compress` — compress images; `npm run compress:preview` shows savings without writing
+- `npm run migrate` — migrate `campaigns.json` from old array format to current key-based format
 - `_site/` is gitignored
 
 ## Dev server preview URLs (localhost:3000)

--- a/README.md
+++ b/README.md
@@ -88,11 +88,14 @@ Every checkout template includes `presell.html` and `landing.html` — a full pr
 Run these inside the repository root:
 
 ```bash
-npm run dev        # interactive campaign picker + dev server
-npm run build      # build all campaigns to _site/
-npm run clone      # duplicate an existing local campaign to a new slug
-npm run compress   # optimise images
-npm run config     # set Campaigns App API keys
+npm run dev              # interactive campaign picker + dev server
+npm run build            # build all campaigns to _site/
+npm run clone            # duplicate an existing local campaign to a new slug
+npm run compress         # optimise images
+npm run compress:preview # preview compression savings without writing files
+npm run config           # set Campaigns App API keys
+npm run start            # interactive launcher (dev / compress / clone / config menu)
+npm run migrate          # migrate campaigns.json from old array format to current key-based format
 ```
 
 ---
@@ -110,6 +113,8 @@ Copy [docs/campaign-page-kit-template-context.md](docs/campaign-page-kit-templat
 ```bash
 curl -o CLAUDE.md https://raw.githubusercontent.com/NextCommerceCo/campaign-cart-starter-templates/main/docs/campaign-page-kit-template-context.md
 ```
+
+Or pass `--ai-context claude` to `campaign-init` and it will write `CLAUDE.md` automatically during setup. Re-running `campaign-init --ai-context claude` refreshes it from the latest upstream; add `--keep-ai-context` to preserve any hand edits. Other supported targets: `--ai-context cursor` (`.cursor/rules/`), `--ai-context copilot` (`.github/copilot-instructions.md`), `--ai-context codex` (`AGENTS.md`).
 
 This gives your AI assistant the context it needs to work correctly with Campaign Cart templates — project structure, Liquid filters, SDK attributes, config, and task checklists. Without it, the assistant will not know the correct SDK version, required `campaigns.json` fields, or how to use `campaign_asset` / `campaign_link` / `campaign_include`.
 

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -12,7 +12,7 @@
    ```bash
    cp docs/campaign-page-kit-template-context.md CLAUDE.md
    ```
-   If this file came from a GitHub URL, write it to `CLAUDE.md` in the working directory directly. For **landing / presell** work, also open [pre-checkout-pages.md](https://github.com/NextCommerceCo/campaign-cart-starter-templates/blob/main/docs/pre-checkout-pages.md) (that guide does not ship inside this single file).
+   If this file came from a GitHub URL, write it to `CLAUDE.md` in the working directory directly. Alternatively, re-running `campaign-init` with `--ai-context claude` writes this file automatically (pass `--keep-ai-context` to preserve hand edits). For **landing / presell** work, also open [pre-checkout-pages.md](https://github.com/NextCommerceCo/campaign-cart-starter-templates/blob/main/docs/pre-checkout-pages.md) (that guide does not ship inside this single file).
 
 2. **Look up the current `sdk_version`** — do not guess or use a version from your training data. Read `_data/campaigns.json` from the [campaign-cart-starter-templates repo](https://github.com/NextCommerceCo/campaign-cart-starter-templates) and copy the exact `sdk_version` string from there. It changes with every SDK release.
 
@@ -130,28 +130,28 @@ Registers every campaign. The `campaign` object in Liquid templates comes from h
 
 ```json
 {
-  "campaigns": [
-    {
-      "name": "My Campaign",
-      "slug": "my-campaign",
-      "sdk_version": "0.4.18",
-      "store_name": "Acme Store",
-      "store_url": "https://acme.com",
-      "store_phone": "1-800-555-0100",
-      "store_phone_tel": "tel:+18005550100",
-      "store_terms": "https://acme.com/terms",
-      "store_privacy": "https://acme.com/privacy",
-      "store_contact": "https://acme.com/contact",
-      "store_returns": "https://acme.com/returns",
-      "store_shipping": "https://acme.com/shipping",
-      "gtm_id": "GTM-XXXXXXX",
-      "fb_pixel_id": "123456789012345"
-    }
-  ]
+  "my-campaign": {
+    "name": "My Campaign",
+    "entry_url": "presell",
+    "sdk_version": "0.4.18",
+    "store_name": "Acme Store",
+    "store_url": "https://acme.com",
+    "store_phone": "1-800-555-0100",
+    "store_phone_tel": "tel:+18005550100",
+    "store_terms": "https://acme.com/terms",
+    "store_privacy": "https://acme.com/privacy",
+    "store_contact": "https://acme.com/contact",
+    "store_returns": "https://acme.com/returns",
+    "store_shipping": "https://acme.com/shipping",
+    "gtm_id": "GTM-XXXXXXX",
+    "fb_pixel_id": "123456789012345"
+  }
 }
 ```
 
-Add any additional key to a campaign entry and it becomes available as `{{ campaign.key }}` on every page in that campaign.
+The top-level key is the campaign slug. Add any additional key to a campaign entry and it becomes available as `{{ campaign.key }}` on every page in that campaign.
+
+**`entry_url`** — optional. The page slug `npm run dev` opens in the browser (e.g. `"presell"`). Omit to use the kit default.
 
 **`sdk_version`** — must be a **pinned semver string** from the starter reference (e.g. `"0.4.18"`), never `"latest"`. A wrong or stale version causes subtle Campaign Cart runtime behaviour with no obvious build error.
 
@@ -243,6 +243,7 @@ Includes a file from the campaign's `_includes/` directory.
 | Variable | Source |
 |----------|--------|
 | `{{ campaign.name }}` | campaigns.json |
+| `{{ campaign.entry_url }}` | campaigns.json (optional) |
 | `{{ campaign.sdk_version }}` | campaigns.json |
 | `{{ campaign.store_name }}` | campaigns.json |
 | `{{ campaign.store_phone }}` | campaigns.json |
@@ -733,11 +734,14 @@ For single-package upsells without voucher-driven pricing. If the upsell uses Ca
 Run from inside your project directory (where `package.json` is):
 
 ```bash
-npm run dev          # interactive campaign picker + dev server
-npm run build        # build all campaigns to _site/
-npm run clone        # duplicate a campaign to a new slug
-npm run config       # set API key for a campaign
-npm run compress     # compress images in a campaign
+npm run dev              # interactive campaign picker + dev server
+npm run build            # build all campaigns to _site/
+npm run clone            # duplicate a campaign to a new slug
+npm run config           # set API key for a campaign
+npm run compress         # compress images in a campaign
+npm run compress:preview # preview compression savings without writing files
+npm run start            # interactive launcher (dev / compress / clone / config menu)
+npm run migrate          # migrate campaigns.json from old array format to current key-based format
 ```
 
 ---


### PR DESCRIPTION
- Fix campaigns.json example from old array format to current key-based format
- Add entry_url field docs across all three doc files
- Add compress:preview, start, and migrate to npm scripts in all docs
- Document --ai-context / --keep-ai-context flags for campaign-init