### PR TITLE
Add agent-friendly template contracts

### DIFF
--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -16,9 +16,10 @@
 
 2. **Look up the current `sdk_version`** — do not guess or use a version from your training data. Read `_data/campaigns.json` from the [campaign-cart-starter-templates repo](https://github.com/NextCommerceCo/campaign-cart-starter-templates) and copy the exact `sdk_version` string from there. It changes with every SDK release.
 
-3. **Fetch the commerce surface catalog** before touching any template-family commerce components. It documents the Liquid params for each family's partials (bundle selector, payment methods, bumps, upsells, receipt, etc.):
+3. **Fetch the commerce surface catalog** before touching any template-family commerce components. It documents the Liquid params for each family's partials (bundle selector, payment methods, bumps, upsells, receipt, etc.) and includes per-family `agentContract` blocks plus fixture specs for mapping CampaignSpec/API truth into starter frontmatter:
    - Human-readable: https://raw.githubusercontent.com/NextCommerceCo/campaign-cart-starter-templates/main/docs/commerce-surface-catalog.md
    - Machine-readable: https://raw.githubusercontent.com/NextCommerceCo/campaign-cart-starter-templates/main/docs/commerce-surface-catalog.json
+   - Fixture specs: https://github.com/NextCommerceCo/campaign-cart-starter-templates/tree/main/docs/fixtures/campaign-specs
 
 4. **Include `gtm_id` and `fb_pixel_id` keys on every `campaigns.json` entry** — set them intentionally:
    - **`""` (empty string)** — layout **does not** inject GTM / Meta snippets in these starter templates (`base.html` uses `{% if campaign.gtm_id != "" %}` / `{% if campaign.fb_pixel_id != "" %}`).
@@ -70,6 +71,16 @@ High confidence means `>= 0.85` in the commerce surface JSON catalog. If the fam
 Reference catalog: [commerce-surface-catalog.md](https://raw.githubusercontent.com/NextCommerceCo/campaign-cart-starter-templates/main/docs/commerce-surface-catalog.md) and [commerce-surface-catalog.json](https://raw.githubusercontent.com/NextCommerceCo/campaign-cart-starter-templates/main/docs/commerce-surface-catalog.json).
 
 Current first-class families include `olympus`, `limos`, `demeter`, `olympus-mv-single-step`, `olympus-mv-two-step`, `shop-single-step`, and `shop-three-step`. This list should grow as the commerce surface library grows.
+
+For each first-class family, read `families[family].agentContract` in the JSON catalog before patching checkout, upsell, or receipt frontmatter. Treat `sharedFrontmatterVocabulary` as the cross-family dictionary:
+
+- `packages.*` values come from CampaignSpec page packages and Campaigns API package `ref_id`s.
+- `shipping_methods.*` values come from CampaignSpec/API shipping method `ref_id`s and are checkout/cart behavior only.
+- `bundles` and `variant_slots` define selector rows; prefer `quantity` plus `packages.main_package` over hand-written item JSON unless the spec needs custom item sets.
+- `order_bump`, `upsell_offer`, and `upsell_bundle_tiers` must be removed or changed when the target campaign does not expose the referenced package/voucher.
+- `receipt_summary` preserves SDK order-item template ids; do not rewrite receipt item templates when frontmatter can express the change.
+
+The fixtures in `docs/fixtures/campaign-specs/` are examples, not live Campaigns App exports. Use their `sdk_hints.frontmatter` blocks to understand the mapping, then replace every numeric `ref_id` from the target CampaignSpec/API.
 
 ---
 

--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -1,6 +1,7 @@
 {
-  "version": 1,
+  "version": 2,
   "purpose": "Routing catalog for matching designed HTML to Campaign Cart starter template families and commerce-ready surfaces. Keep matching cheap and deterministic; ask the user when confidence is not high.",
+  "agentContractVersion": 1,
   "confidencePolicy": {
     "highThreshold": 0.85,
     "askUserBelow": 0.85,
@@ -18,6 +19,166 @@
       "unique commerce structure",
       "distinctive checkout layout structure",
       "class-name fingerprints"
+    ]
+  },
+  "sharedFrontmatterVocabulary": {
+    "packages": {
+      "purpose": "Named Campaigns App package ref_ids used by checkout selectors, bumps, and display bindings.",
+      "canonicalKeys": [
+        "main_package",
+        "prepurchase_1",
+        "prepurchase_2"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec funnels[].pages[].packages",
+        "Campaigns API packages[].ref_id"
+      ],
+      "demoOnlyValues": [
+        1,
+        7,
+        9
+      ],
+      "agentRule": "Replace starter refs from the target CampaignSpec/API. Remove optional bump surfaces when the referenced prepurchase package is absent."
+    },
+    "shipping_methods": {
+      "purpose": "Named Campaigns App shipping method ref_ids used by checkout selector cards.",
+      "canonicalKeys": [
+        "standard",
+        "free"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec shipping_methods[]",
+        "Campaigns API shipping_options[].ref_id"
+      ],
+      "demoOnlyValues": [
+        2,
+        1
+      ],
+      "agentRule": "Use only on checkout/cart selector surfaces. Do not carry starter refs between campaigns; remove shipping_method rows when the target campaign has no matching method."
+    },
+    "bundles": {
+      "purpose": "Checkout bundle-card rows for package quantity tiers.",
+      "canonicalKeys": [
+        "id",
+        "quantity",
+        "shipping_method",
+        "selected",
+        "title_prefix",
+        "badge_text",
+        "items_json"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec checkout page packages/offers",
+        "Campaigns API package and shipping refs"
+      ],
+      "agentRule": "Prefer package_id plus quantity. Use explicit items_json only for genuinely custom item sets."
+    },
+    "variant_slots": {
+      "purpose": "MV/configurable bundle slots for selector rows and later variant choice stages.",
+      "canonicalKeys": [
+        "id",
+        "quantity",
+        "shipping_method",
+        "selected",
+        "title",
+        "label_text",
+        "configurable"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec MV checkout/select pages",
+        "Campaigns API package refs and variant config"
+      ],
+      "agentRule": "Keep selector ids aligned with data-next-bundle-slots-for. Preserve configurable bundle item shape unless the API/spec says the package is non-configurable."
+    },
+    "order_bump": {
+      "purpose": "Pre-purchase add-on toggle configuration.",
+      "canonicalKeys": [
+        "order_bump_variant",
+        "order_bump.check01",
+        "order_bump.switch01"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec checkout page offers/packages",
+        "Campaigns API package refs"
+      ],
+      "agentRule": "Enable only when the target campaign has the referenced package or offer. Do not leave warranty/insurance starter modules pointed at missing package refs."
+    },
+    "upsell_offer": {
+      "purpose": "Single-card post-purchase bundle upsell offer.",
+      "canonicalKeys": [
+        "package_id",
+        "selector_id",
+        "bundle_id",
+        "items_json",
+        "vouchers_json",
+        "accept_text",
+        "decline_text"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec upsell/downsell pages",
+        "Campaigns API package refs and vouchers/offers"
+      ],
+      "agentRule": "Post-purchase upsells do not use shipping_methods. Package refs and vouchers must come from the upsell page contract."
+    },
+    "upsell_bundle_tiers": {
+      "purpose": "Tiered post-purchase bundle upsell rows.",
+      "canonicalKeys": [
+        "id",
+        "items_json",
+        "vouchers_json",
+        "selected",
+        "label",
+        "quantity"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec upsell/downsell pages",
+        "Campaigns API package refs and vouchers/offers"
+      ],
+      "agentRule": "Keep display tier and in-offer selector ids paired. Do not attach checkout shipping refs to upsell cards."
+    },
+    "receipt_summary": {
+      "purpose": "Receipt order-item template ids and summary copy.",
+      "canonicalKeys": [
+        "title",
+        "scroll_hint",
+        "mobile_item_template_id",
+        "desktop_item_template_id"
+      ],
+      "sourceOfTruth": [
+        "Template receipt include contract",
+        "SDK order display data"
+      ],
+      "agentRule": "Preserve data-next-order-items templates and ids; change copy only through frontmatter when the family exposes it."
+    },
+    "payment_flags": {
+      "purpose": "Visible payment method rows and express wallet flags.",
+      "canonicalKeys": [
+        "show_paypal",
+        "show_klarna",
+        "show_apple_pay",
+        "show_google_pay"
+      ],
+      "sourceOfTruth": [
+        "CampaignSpec payment methods",
+        "Campaigns API/payment provider capability"
+      ],
+      "agentRule": "Payment config, CampaignSpec/API support, and visible rows must agree."
+    }
+  },
+  "campaignSpecFixturePolicy": {
+    "directory": "docs/fixtures/campaign-specs",
+    "purpose": "Small CampaignSpec-shaped examples for agent contract reasoning. They are not live Campaigns App exports.",
+    "requiredShape": [
+      "campaign.id",
+      "campaign.name",
+      "campaign.currency",
+      "campaign.language",
+      "funnels[].pages[]"
+    ],
+    "fixtureOnlyConventions": [
+      "sdk_hints.template_family names the starter family for the fixture only.",
+      "sdk_hints.frontmatter shows the intended starter-template frontmatter mapping.",
+      "ref_id values are illustrative and must be replaced from the target Campaigns API."
     ]
   },
   "families": {
@@ -46,7 +207,117 @@
         "shipping_methods",
         "swiper_slides",
         "swiper_thumbs"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Reference single-step checkout family with tiered bundle cards and optional pre-purchase bumps.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "campaign currency/language/payment/tracking",
+            "checkout page packages/offers",
+            "shipping_methods[]",
+            "upsell/receipt routing"
+          ],
+          "campaignsApi": [
+            "packages[].ref_id",
+            "shipping_options[].ref_id",
+            "payment method capability"
+          ],
+          "starterTemplate": [
+            "stable SDK DOM shape",
+            "family-local includes",
+            "page frontmatter contract"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "packages.main_package",
+            "shipping_methods.standard",
+            "bundles[].quantity",
+            "bundles[].shipping_method"
+          ],
+          "optionalWhenSupported": [
+            "shipping_methods.free",
+            "order_bump_variant",
+            "packages.prepurchase_1",
+            "packages.prepurchase_2",
+            "swiper_slides",
+            "swiper_thumbs",
+            "payment_flags"
+          ],
+          "demoOnlyValues": [
+            "packages.main_package=1",
+            "packages.prepurchase_1=7",
+            "packages.prepurchase_2=9",
+            "shipping_methods.standard=2",
+            "shipping_methods.free=1"
+          ],
+          "replaceFromSpecOrApi": [
+            "packages.*",
+            "shipping_methods.*",
+            "bundles[].shipping_method",
+            "order_bump.*.package_id"
+          ],
+          "removeWhenUnsupported": [
+            "bundles[].shipping_method when no tier-specific shipping exists",
+            "bump includes when prepurchase packages are absent",
+            "unsupported payment method rows"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "tiered bundle selector",
+            "partials": [
+              "bundle-selector.html"
+            ],
+            "ownedInputs": [
+              "packages",
+              "shipping_methods",
+              "bundles"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-selector",
+              "data-next-bundle-card"
+            ]
+          },
+          {
+            "name": "payment shell",
+            "partials": [
+              "payment-methods.html",
+              "express-checkout.html"
+            ],
+            "ownedInputs": [
+              "payment_flags"
+            ],
+            "sdkRoots": [
+              "data-next-payment-method",
+              "data-next-payment-form",
+              "data-next-express-checkout"
+            ]
+          },
+          {
+            "name": "order bump",
+            "partials": [
+              "bump-check01.html",
+              "bump-switch01.html"
+            ],
+            "ownedInputs": [
+              "packages",
+              "order_bump"
+            ],
+            "sdkRoots": [
+              "data-next-package-toggle",
+              "data-next-toggle-card"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/olympus-tiered-standard-free.json"
+        ],
+        "agentNotes": [
+          "Use this family only when the design really has the Olympus tiered checkout shape; do not default here from a generic checkout."
+        ]
+      }
     },
     "limos": {
       "description": "Single-step checkout with dense offer framing and native bundle quantity controls.",
@@ -88,7 +359,118 @@
         "receipt_summary",
         "upsell_bundle_tiers",
         "upsell_offer"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Single-step checkout with one visible offer card and a native quantity stepper.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "checkout page package",
+            "standard shipping method when selector shipping is used",
+            "optional prepurchase packages",
+            "upsell/receipt routing"
+          ],
+          "campaignsApi": [
+            "packages[].ref_id",
+            "shipping_options[].ref_id",
+            "offers/vouchers for upsell pages"
+          ],
+          "starterTemplate": [
+            "stable SDK DOM shape",
+            "family-local includes",
+            "page frontmatter contract"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "packages.main_package",
+            "single_offer.shipping_method",
+            "shipping_methods.standard"
+          ],
+          "optionalWhenSupported": [
+            "single_offer.quantity_min",
+            "single_offer.quantity_max",
+            "single_offer.show_quantity_stepper",
+            "order_bump_variant",
+            "upsell_offer",
+            "upsell_bundle_tiers",
+            "receipt_summary"
+          ],
+          "demoOnlyValues": [
+            "single_offer.package_id=1",
+            "shipping_methods.standard=2",
+            "packages.prepurchase_1=7",
+            "packages.prepurchase_2=9"
+          ],
+          "replaceFromSpecOrApi": [
+            "packages.*",
+            "shipping_methods.standard",
+            "single_offer.package_id",
+            "order_bump.*.package_id",
+            "upsell_offer.package_id",
+            "upsell_bundle_tiers[].items_json"
+          ],
+          "removeWhenUnsupported": [
+            "single_offer.shipping_method when the target campaign has no selector shipping",
+            "order bump variants when prepurchase packages are absent"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "single offer selector",
+            "partials": [
+              "single-offer-quantity-selector.html"
+            ],
+            "ownedInputs": [
+              "single_offer",
+              "packages",
+              "shipping_methods"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-selector",
+              "data-next-bundle-card",
+              "data-next-bundle-qty-for"
+            ]
+          },
+          {
+            "name": "upsell offers",
+            "partials": [
+              "upsell-bundle-stepper-offer.html",
+              "upsell-bundle-tier-pills-offer.html",
+              "upsell-bundle-tier-cards-offer.html"
+            ],
+            "ownedInputs": [
+              "upsell_offer",
+              "upsell_bundle_tiers"
+            ],
+            "sdkRoots": [
+              "data-next-upsell",
+              "data-next-bundle-selector"
+            ]
+          },
+          {
+            "name": "receipt summary",
+            "partials": [
+              "receipt-skeleton.html",
+              "receipt-order-summary-mobile.html",
+              "receipt-order-summary-desktop.html"
+            ],
+            "ownedInputs": [
+              "receipt_summary"
+            ],
+            "sdkRoots": [
+              "data-next-skeleton",
+              "data-next-order-items"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/limos-single-offer-quantity.json"
+        ],
+        "agentNotes": [
+          "Limos is quantity-stepper first; do not force 1x/2x/3x visual tier cards into this family."
+        ]
+      }
     },
     "demeter": {
       "description": "Single-step editorial/luxury checkout with spacious tier cards and open cart summary.",
@@ -130,7 +512,123 @@
         "receipt_summary",
         "upsell_bundle_tiers",
         "upsell_offer"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Editorial single-step checkout with tier cards and an open side summary.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "checkout page package tiers",
+            "shipping_methods[]",
+            "optional prepurchase packages",
+            "upsell/receipt routing"
+          ],
+          "campaignsApi": [
+            "packages[].ref_id",
+            "shipping_options[].ref_id",
+            "offers/vouchers for upsell pages"
+          ],
+          "starterTemplate": [
+            "stable SDK DOM shape",
+            "family-local includes",
+            "page frontmatter contract"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "packages.main_package",
+            "shipping_methods.standard",
+            "bundles[].quantity",
+            "bundles[].shipping_method"
+          ],
+          "optionalWhenSupported": [
+            "shipping_methods.free",
+            "cart_summary_variant",
+            "order_bump_variant",
+            "upsell_offer",
+            "upsell_bundle_tiers",
+            "receipt_summary"
+          ],
+          "demoOnlyValues": [
+            "packages.main_package=1",
+            "shipping_methods.standard=2",
+            "shipping_methods.free=1",
+            "packages.prepurchase_1=7",
+            "packages.prepurchase_2=9"
+          ],
+          "replaceFromSpecOrApi": [
+            "packages.*",
+            "shipping_methods.*",
+            "bundles[].shipping_method",
+            "order_bump.*.package_id",
+            "upsell_offer.package_id",
+            "upsell_bundle_tiers[].items_json"
+          ],
+          "removeWhenUnsupported": [
+            "bundles[].shipping_method when no tier-specific shipping exists",
+            "order bump variants when prepurchase packages are absent"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "editorial tier selector",
+            "partials": [
+              "editorial-tier-selector.html"
+            ],
+            "ownedInputs": [
+              "packages",
+              "shipping_methods",
+              "bundles",
+              "price_display_variant"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-selector",
+              "data-next-bundle-card"
+            ]
+          },
+          {
+            "name": "side summary and bumps",
+            "partials": [
+              "cart-summary03.html",
+              "bump-check01.html",
+              "bump-switch01.html"
+            ],
+            "ownedInputs": [
+              "cart_summary_variant",
+              "packages",
+              "order_bump"
+            ],
+            "sdkRoots": [
+              "data-next-cart-summary",
+              "data-next-package-toggle"
+            ]
+          },
+          {
+            "name": "upsell and receipt includes",
+            "partials": [
+              "upsell-bundle-stepper-offer.html",
+              "upsell-bundle-tier-pills-offer.html",
+              "upsell-bundle-tier-cards-offer.html",
+              "receipt-skeleton.html"
+            ],
+            "ownedInputs": [
+              "upsell_offer",
+              "upsell_bundle_tiers",
+              "receipt_summary"
+            ],
+            "sdkRoots": [
+              "data-next-upsell",
+              "data-next-order-items"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/demeter-editorial-tiered.json"
+        ],
+        "agentNotes": [
+          "Demeter text such as shipping labels is copy, not proof; validate actual free/standard shipping against spec/API before launch."
+        ]
+      }
     },
     "shop-single-step": {
       "description": "Highly used shop-style single-step checkout with compact cart summary, receipt, and three bundle upsell variants.",
@@ -160,7 +658,115 @@
         "swiper_thumbs",
         "upsell_bundle_tiers",
         "upsell_offer"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Shop-style single-step checkout with compact cart summary plus promoted receipt and upsell includes.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "checkout page payment/shipping support",
+            "optional order bump package",
+            "upsell pages/packages/offers",
+            "receipt routing"
+          ],
+          "campaignsApi": [
+            "packages[].ref_id",
+            "payment method capability",
+            "offers/vouchers for upsell pages"
+          ],
+          "starterTemplate": [
+            "shop checkout DOM shape",
+            "family-local receipt and upsell includes",
+            "runtime shipping/address fields"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "next_url",
+            "page_type=checkout"
+          ],
+          "optionalWhenSupported": [
+            "receipt_summary",
+            "upsell_offer",
+            "upsell_bundle_tiers",
+            "swiper_slides",
+            "swiper_thumbs",
+            "payment_flags"
+          ],
+          "demoOnlyValues": [
+            "upsell_offer.package_id=3",
+            "upsell_offer.vouchers_json=[\"UP50\"]",
+            "upsell_bundle_tiers packageId=3"
+          ],
+          "replaceFromSpecOrApi": [
+            "upsell_offer.*",
+            "upsell_bundle_tiers[].items_json",
+            "upsell_bundle_tiers[].vouchers_json",
+            "receipt_summary.*",
+            "payment_flags"
+          ],
+          "removeWhenUnsupported": [
+            "unsupported payment method rows",
+            "order bump when no bump package exists",
+            "upsell pages not present in the funnel"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "shop checkout shell",
+            "partials": [
+              "cart-summary04.html",
+              "express-checkout.html",
+              "payment-methods.html",
+              "bump-check02.html"
+            ],
+            "ownedInputs": [
+              "payment_flags"
+            ],
+            "sdkRoots": [
+              "data-next-cart-summary",
+              "data-next-express-checkout",
+              "data-next-payment-method"
+            ]
+          },
+          {
+            "name": "shop upsell offers",
+            "partials": [
+              "upsell-bundle-stepper-offer.html",
+              "upsell-bundle-tier-pills-offer.html",
+              "upsell-bundle-tier-cards-offer.html"
+            ],
+            "ownedInputs": [
+              "upsell_offer",
+              "upsell_bundle_tiers"
+            ],
+            "sdkRoots": [
+              "data-next-upsell",
+              "data-next-bundle-selector"
+            ]
+          },
+          {
+            "name": "shop receipt",
+            "partials": [
+              "receipt-skeleton.html",
+              "receipt-order-summary-mobile.html",
+              "receipt-order-summary-desktop.html"
+            ],
+            "ownedInputs": [
+              "receipt_summary"
+            ],
+            "sdkRoots": [
+              "data-next-order-items"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json"
+        ],
+        "agentNotes": [
+          "Shop-single-step is a real family, not a generic fallback. Preserve its summary/payment template roots."
+        ]
+      }
     },
     "olympus-mv-single-step": {
       "description": "Olympus-style single-step checkout with configurable multi-variant bundle slots in the checkout page.",
@@ -193,7 +799,97 @@
         "swiper_slides",
         "swiper_thumbs",
         "variant_slots"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Olympus-style single-step checkout where bundle quantity selection and configurable variant slots live on the same page.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "configurable checkout page package",
+            "variant slot expectations",
+            "shipping_methods[]",
+            "payment/routing"
+          ],
+          "campaignsApi": [
+            "configurable package ref_id",
+            "variant product data",
+            "shipping_options[].ref_id"
+          ],
+          "starterTemplate": [
+            "mv-configurable-selector.html",
+            "mv slot DOM contract",
+            "checkout-olympus-mv-full.js"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "packages.main_package",
+            "shipping_methods.standard",
+            "variant_slots[].id",
+            "variant_slots[].quantity",
+            "variant_slots[].shipping_method"
+          ],
+          "optionalWhenSupported": [
+            "shipping_methods.free",
+            "swiper_slides",
+            "swiper_thumbs",
+            "variant_slots[].label_text"
+          ],
+          "demoOnlyValues": [
+            "packages.main_package=1",
+            "shipping_methods.standard=2",
+            "shipping_methods.free=1"
+          ],
+          "replaceFromSpecOrApi": [
+            "packages.main_package",
+            "shipping_methods.*",
+            "variant_slots[].shipping_method"
+          ],
+          "removeWhenUnsupported": [
+            "variant slot rows unsupported by the target spec/API",
+            "free shipping row if no free method exists"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "MV configurable selector",
+            "partials": [
+              "mv-configurable-selector.html"
+            ],
+            "ownedInputs": [
+              "packages",
+              "shipping_methods",
+              "variant_slots"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-selector",
+              "data-next-bundle-slots-for",
+              "data-next-bundle-slot-template-id"
+            ]
+          },
+          {
+            "name": "MV payment and summary",
+            "partials": [
+              "payment-methods.html",
+              "cart-summary03.html",
+              "cart-summary04.html"
+            ],
+            "ownedInputs": [
+              "payment_flags"
+            ],
+            "sdkRoots": [
+              "data-next-payment-method",
+              "data-next-cart-summary"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json"
+        ],
+        "agentNotes": [
+          "Keep slot ids aligned across selector rows, bundle slots, and JS."
+        ]
+      }
     },
     "olympus-mv-two-step": {
       "description": "Olympus-style multi-variant flow with a separate variant select step before checkout.",
@@ -226,7 +922,238 @@
         "select_step",
         "selector_id",
         "variant_slots"
-      ]
+      ],
+      "agentContract": {
+        "status": "agent-ready",
+        "templateRole": "Olympus-style MV flow with separate select step before checkout/payment.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "select page package/variant choices",
+            "checkout routing",
+            "shipping_methods[]",
+            "payment/routing"
+          ],
+          "campaignsApi": [
+            "configurable package ref_id",
+            "variant product data",
+            "shipping_options[].ref_id"
+          ],
+          "starterTemplate": [
+            "mv-selection-step.html",
+            "mv-slot-stage.html",
+            "checkout-olympus-mv-selection.js",
+            "checkout-olympus-mv-full.js"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "packages.main_package",
+            "shipping_methods.standard",
+            "variant_slots[].id",
+            "variant_slots[].quantity",
+            "variant_slots[].shipping_method",
+            "select_step.selector_id"
+          ],
+          "optionalWhenSupported": [
+            "shipping_methods.free",
+            "checkout_step.selector_id",
+            "swiper_slides",
+            "swiper_thumbs"
+          ],
+          "demoOnlyValues": [
+            "packages.main_package=1",
+            "shipping_methods.standard=2",
+            "shipping_methods.free=1"
+          ],
+          "replaceFromSpecOrApi": [
+            "packages.main_package",
+            "shipping_methods.*",
+            "variant_slots[].shipping_method"
+          ],
+          "removeWhenUnsupported": [
+            "variant slot rows unsupported by the target spec/API",
+            "free shipping row if no free method exists"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "MV select step",
+            "partials": [
+              "mv-selection-step.html"
+            ],
+            "ownedInputs": [
+              "select_step",
+              "packages",
+              "shipping_methods",
+              "variant_slots"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-selector",
+              "data-next-bundle-card"
+            ]
+          },
+          {
+            "name": "MV slot stage",
+            "partials": [
+              "mv-slot-stage.html"
+            ],
+            "ownedInputs": [
+              "checkout_step",
+              "variant_slots"
+            ],
+            "sdkRoots": [
+              "data-next-bundle-slots-for",
+              "data-next-bundle-slot-template-id"
+            ]
+          },
+          {
+            "name": "MV payment and summary",
+            "partials": [
+              "payment-methods.html",
+              "cart-summary03.html",
+              "cart-summary04.html"
+            ],
+            "ownedInputs": [
+              "payment_flags"
+            ],
+            "sdkRoots": [
+              "data-next-payment-method",
+              "data-next-cart-summary"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json"
+        ],
+        "agentNotes": [
+          "Select-step ids and checkout-step ids must remain synchronized; ask if a design blends one-step and two-step MV patterns."
+        ]
+      }
+    },
+    "shop-three-step": {
+      "description": "Shop-style three-step checkout with separate information, shipping, and billing pages plus dynamic shipping options.",
+      "frontmatterStatus": "partial",
+      "strongSignals": [
+        "shop-three-step in spec, path, or export metadata",
+        "information.html -> shipping.html -> billing.html flow",
+        "checkout-shop-three-shipping.js dynamic shipping options",
+        "separate shipping method page before billing"
+      ],
+      "canonicalSurfaces": {
+        "informationStep": "shipping/contact form",
+        "shippingStep": "dynamic shipping methods from SDK getShippingMethods()",
+        "billingStep": "payment-methods and checkout review",
+        "receipt": "receipt-skeleton",
+        "upsell": "bundle-stepper|bundle-tier-pills|bundle-tier-cards"
+      },
+      "frontmatterInputsNeeded": [
+        "receipt_summary",
+        "upsell_offer",
+        "upsell_bundle_tiers"
+      ],
+      "frontmatterInputsObserved": [
+        "shipping_steps",
+        "swiper_slides",
+        "swiper_thumbs"
+      ],
+      "agentContract": {
+        "status": "partial-needs-promotion",
+        "templateRole": "Shop checkout split into information, shipping, and billing steps; shipping methods are runtime-derived, not frontmatter refs.",
+        "sourceOfTruth": {
+          "campaignSpec": [
+            "three-step checkout routing",
+            "shipping_methods[]",
+            "payment support",
+            "upsell pages/packages/offers",
+            "receipt routing"
+          ],
+          "campaignsApi": [
+            "shipping_options[].ref_id via SDK getShippingMethods()",
+            "payment method capability",
+            "offers/vouchers for upsell pages"
+          ],
+          "starterTemplate": [
+            "multi-step form sequencing",
+            "checkout-shop-three-shipping.js",
+            "shop receipt and upsell DOM shape"
+          ]
+        },
+        "frontmatter": {
+          "requiredWhenCloning": [
+            "information.next_url=shipping.html",
+            "shipping.next_url=billing.html",
+            "billing.next_url=upsell-bundle-stepper.html"
+          ],
+          "optionalWhenSupported": [
+            "receipt_summary",
+            "upsell_offer",
+            "upsell_bundle_tiers",
+            "swiper_slides",
+            "swiper_thumbs"
+          ],
+          "demoOnlyValues": [
+            "inline upsell packageId=3",
+            "inline upsell vouchers=[\"UP50\"]"
+          ],
+          "replaceFromSpecOrApi": [
+            "inline upsell package/voucher refs until promoted",
+            "payment method visibility",
+            "receipt summary markup once promoted"
+          ],
+          "removeWhenUnsupported": [
+            "unsupported payment method rows",
+            "upsell pages not present in the funnel"
+          ]
+        },
+        "surfaces": [
+          {
+            "name": "dynamic shipping step",
+            "partials": [
+              "assets/js/checkout-shop-three-shipping.js"
+            ],
+            "ownedInputs": [
+              "Campaigns API shipping methods"
+            ],
+            "sdkRoots": [
+              "data-next-shipping-id"
+            ]
+          },
+          {
+            "name": "billing payment shell",
+            "partials": [
+              "payment-methods.html"
+            ],
+            "ownedInputs": [
+              "payment_flags"
+            ],
+            "sdkRoots": [
+              "data-next-payment-method",
+              "data-next-payment-form"
+            ]
+          },
+          {
+            "name": "upsell and receipt surfaces",
+            "partials": [
+              "inline today; promote to shop-single-step parity includes next"
+            ],
+            "ownedInputs": [
+              "upsell_offer",
+              "upsell_bundle_tiers",
+              "receipt_summary"
+            ],
+            "sdkRoots": [
+              "data-next-upsell",
+              "data-next-order-items"
+            ]
+          }
+        ],
+        "fixtures": [
+          "docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json"
+        ],
+        "agentNotes": [
+          "Do not add shipping_methods frontmatter here for checkout methods. The shipping step renders from the live SDK/API method list."
+        ]
+      }
     }
   },
   "askUserPromptTemplate": "I can map this design to more than one commerce template family: {candidates}. The ambiguous surfaces are {surfaces}. Which family should I use before wiring SDK components?"

--- a/docs/commerce-surface-catalog.md
+++ b/docs/commerce-surface-catalog.md
@@ -2,7 +2,7 @@
 
 This catalog is a routing aid for agents and developers assembling Campaign Cart funnels from designed HTML. It should stay dry and predictable: use it to pick known template-family surfaces, not to make expensive visual guesses.
 
-Machine-readable companion: [`commerce-surface-catalog.json`](./commerce-surface-catalog.json).
+Machine-readable companion: [`commerce-surface-catalog.json`](./commerce-surface-catalog.json). The JSON catalog now includes an `agentContract` block for each first-class checkout family plus `sharedFrontmatterVocabulary` for cross-family fields such as `packages`, `shipping_methods`, `bundles`, `variant_slots`, `order_bump`, `upsell_offer`, `upsell_bundle_tiers`, `receipt_summary`, and payment flags.
 
 ## Confidence Policy
 
@@ -31,8 +31,39 @@ High confidence currently means `>= 0.85`, matching the JSON catalog. If the top
 | `limos` | Partial include/frontmatter API exists | Single offer card with native quantity stepper | `cart-summary02` accordion | Roadflare checkout plus upsell/receipt surfaces are include-owned; upsell exposes `upsell_offer` / `upsell_bundle_tiers`, receipt exposes `receipt_summary`. |
 | `demeter` | Partial include/frontmatter API exists | Editorial tier cards | `cart-summary03` side cart | Veyra checkout plus upsell/receipt surfaces are include-owned; upsell exposes `upsell_offer` / `upsell_bundle_tiers`, receipt exposes `receipt_summary`. |
 | `shop-single-step` | Partial include API exists | Shop checkout with single-step payment | `cart-summary04` checkout summary | Highly used shop flow; checkout, receipt, and upsell SDK surfaces are now include-owned and catalog-wrapped. |
+| `shop-three-step` | Partial contract exists | Information -> shipping -> billing checkout | `cart-summary04` checkout/review shape | Shipping methods are rendered dynamically from `sdk.getShippingMethods()`; do not add Olympus-style `shipping_methods` frontmatter for checkout shipping. |
 | `olympus-mv-single-step` | Partial frontmatter API exists | MV configurable selector in checkout | `cart-summary01/03/04` | First-class MV checkout selector promoted to `mv-configurable-selector.html`; `packages.main_package` now feeds MV bundle item JSON unless a slot overrides `items_json`. |
 | `olympus-mv-two-step` | Partial frontmatter API exists | Select step + checkout review/payment | `cart-summary03/04` | First-class select surface promoted to `mv-selection-step.html` + `mv-slot-stage.html`; `packages.main_package` now feeds MV bundle item JSON unless a slot overrides `items_json`. |
+
+## Agent Contract Layer
+
+The contract layer is intentionally lighter than a campaign readiness check. It does not validate a real CampaignSpec against a live Campaigns API; it documents how an agent should translate spec/API truth into starter-template frontmatter and partial choices.
+
+Use it in this order:
+
+1. Pick the family from cheap catalog signals and ask when ambiguous.
+2. Read `families[family].agentContract` in the JSON catalog.
+3. Replace all `frontmatter.demoOnlyValues` from the target CampaignSpec/API.
+4. Use the family fixture under `docs/fixtures/campaign-specs/` as an example of the mapping shape, not as live data.
+5. Run `npm run lint:agent-contracts` after catalog or fixture changes.
+
+The important boundary is: CampaignSpec/API owns package refs, shipping refs, vouchers, payment support, routing, tracking, footer links, and SEO. Starter templates own the stable SDK DOM shape and family-specific frontmatter vocabulary.
+
+## Fixture Specs
+
+Each first-class checkout family has a small CampaignSpec-shaped fixture:
+
+| Family | Fixture |
+| --- | --- |
+| `olympus` | `docs/fixtures/campaign-specs/olympus-tiered-standard-free.json` |
+| `limos` | `docs/fixtures/campaign-specs/limos-single-offer-quantity.json` |
+| `demeter` | `docs/fixtures/campaign-specs/demeter-editorial-tiered.json` |
+| `shop-single-step` | `docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json` |
+| `shop-three-step` | `docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json` |
+| `olympus-mv-single-step` | `docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json` |
+| `olympus-mv-two-step` | `docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json` |
+
+These fixtures deliberately include `sdk_hints.frontmatter` so agents can see the intended mapping. They are not canonical Campaign Map Builder exports, and every numeric `ref_id` is illustrative.
 
 ## Gap Matrix
 
@@ -53,6 +84,8 @@ High confidence currently means `>= 0.85`, matching the JSON catalog. If the top
 | `shop-single-step` | Checkout summary/payment/bump | Includes: `cart-summary04.html`, `express-checkout.html`, `payment-methods.html`, and `bump-check02.html`; used from `src/shop-single-step/checkout.html`. | Partial: payment flags; summary/bump variants are fixed in the page. | Yes under global checkout CI lint and shop-single-step all-page source/rendered lint. | Add frontmatter selection for summary/bump variants if campaign variants need it. | P1 |
 | `shop-single-step` | Receipt/order confirmation | Includes: `receipt-skeleton.html`, `receipt-order-summary-mobile.html`, and `receipt-order-summary-desktop.html`; used from `src/shop-single-step/receipt.html`. | Yes: `receipt_summary` controls title, scroll hint, and separate mobile/desktop order item template IDs. | Yes under `npm run lint:sdk:shop-single-step:all`; global CI still covers checkout/select only. | Consider a shared receipt summary include across shop templates. | P2 |
 | `shop-single-step` | Upsell selectors/actions | Includes: `upsell-bundle-stepper-offer.html`, `upsell-bundle-tier-pills-offer.html`, and `upsell-bundle-tier-cards-offer.html`; used from the matching upsell pages. | Yes: `upsell_offer` controls package/selector/voucher ids and button copy; `upsell_bundle_tiers` controls tier ids, item JSON, vouchers, labels, and selected state. | Yes under `npm run lint:sdk:shop-single-step:all`; global CI still covers checkout/select only. | Mirror the contract into shop-three-step only after confirming matching markup. | P1 |
+| `shop-three-step` | Dynamic shipping step | `src/shop-three-step/assets/js/checkout-shop-three-shipping.js` renders shipping method radios from `sdk.getShippingMethods()`. | Runtime/API-driven rather than frontmatter-driven; fixture documents this as `runtime_shipping_source`. | Yes under global checkout CI lint for checkout/select pages. | Keep dynamic shipping separate from Olympus-style selector shipping. | P1 |
+| `shop-three-step` | Upsell and receipt surfaces | Upsell/receipt pages currently keep more inline SDK roots than `shop-single-step`. | Partial: catalog agent contract and fixture exist; family-local include promotion remains future work. | Outside promoted all-page lint today. | Promote to shop-single-step parity includes in a focused follow-up. | P1 |
 | `olympus-mv-single-step` | MV selector and variant slots | Include: `src/olympus-mv-single-step/_includes/mv-configurable-selector.html`; used from checkout. | Yes: `checkout_step` controls selector id and headings; `packages.main_package` supplies the package id; `shipping_methods` supplies starter standard/free refs; `variant_slots` controls bundle ids, quantity, optional per-slot `package_id` / `items_json` overrides, shipping method, labels, and selected state. | Yes under `npm run lint:sdk:promoted`. | Add campaign-specific examples after the next MV build. | P1 |
 | `olympus-mv-two-step` | Select step and variant slots | Includes: `mv-selection-step.html` and `mv-slot-stage.html`; used from `src/olympus-mv-two-step/select.html`. | Yes: `select_step` and `checkout_step` keep selector ids aligned; `packages.main_package` supplies the package id; `shipping_methods` supplies starter standard/free refs; `variant_slots` controls bundle ids, quantity, optional per-slot `package_id` / `items_json` overrides, shipping method, labels, and selected state. | Yes under `npm run lint:sdk:promoted`. | Add campaign-specific examples after the next MV two-step build. | P1 |
 | `olympus-mv-*` | Checkout payment and summary | Payment, express checkout, and summary includes have catalog wrappers in both MV families. | Partial/no MV-specific summary contract. | Yes under promoted checkout/select rendered scope. | Add summary variant contract and receipt/upsell scope. | P2 |
@@ -109,6 +142,7 @@ The goal is not a small fixed set of templates. The goal is a growing library of
 - `npm run lint:sdk:promoted` covers promoted checkout/select surfaces for `olympus`, `limos`, `demeter`, `olympus-mv-single-step`, and `olympus-mv-two-step`.
 - `npm run lint:sdk:ci` covers checkout/select pages across all template families.
 - `npm run lint:sdk:shop-single-step:all` covers checkout, upsell, and receipt pages for `shop-single-step`.
+- `npm run lint:agent-contracts` validates the JSON catalog agent contracts and fixture shape.
 - `node scripts/lint-sdk.mjs --scope=limos --pages=all` covers checkout, upsell, and receipt pages for `limos`.
 - `node scripts/lint-sdk.mjs --scope=demeter --pages=all` covers checkout, upsell, and receipt pages for `demeter`.
 

--- a/docs/fixtures/campaign-specs/README.md
+++ b/docs/fixtures/campaign-specs/README.md
@@ -1,0 +1,18 @@
+# CampaignSpec Agent Fixtures
+
+These JSON files are small CampaignSpec-shaped examples for agent reasoning and Sam review. They are not live Campaigns App exports and should not be used as production campaign data.
+
+What they are for:
+
+- Show which CampaignSpec/API values map into each starter template family's frontmatter.
+- Give agents concrete examples for package refs, shipping refs, upsell vouchers, and receipt contracts.
+- Keep template-family examples separate from readiness validation. These fixtures document the handoff shape; they do not prove a real campaign is launch-ready.
+
+Fixture conventions:
+
+- `sdk_hints.template_family` names the intended starter family for the fixture only.
+- `sdk_hints.frontmatter` shows the frontmatter values an agent would write into the template.
+- Numeric `ref_id` values are illustrative. Replace them from the target Campaigns API.
+- `shipping_methods[].key` mirrors the starter frontmatter vocabulary, such as `standard` and `free`.
+
+Run `npm run lint:agent-contracts` after changing these fixtures or `docs/commerce-surface-catalog.json`.

--- a/docs/fixtures/campaign-specs/demeter-editorial-tiered.json
+++ b/docs/fixtures/campaign-specs/demeter-editorial-tiered.json
@@ -1,0 +1,190 @@
+{
+  "campaign": {
+    "id": "fixture-demeter-editorial",
+    "name": "Fixture Demeter Editorial Tiered",
+    "slug": "fixture-demeter",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Demeter Editorial Tiered",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-demeter-editorial-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 1,
+          "label": "Checkout",
+          "template": "src/demeter/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 2
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 3
+            },
+            {
+              "role": "prepurchase_1",
+              "ref_id": 17,
+              "quantity": 1
+            },
+            {
+              "role": "prepurchase_2",
+              "ref_id": 19,
+              "quantity": 1
+            }
+          ],
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "demeter",
+            "frontmatter": {
+              "packages.main_package": 10,
+              "packages.prepurchase_1": 17,
+              "packages.prepurchase_2": 19,
+              "shipping_methods.standard": 20,
+              "shipping_methods.free": 21,
+              "bundles": [
+                {
+                  "id": "bundle-1x",
+                  "quantity": 1,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "bundle-2x",
+                  "quantity": 2,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "bundle-3x",
+                  "quantity": 3,
+                  "shipping_method": "free"
+                }
+              ],
+              "price_display_variant": "compare-unit-total"
+            }
+          }
+        },
+        {
+          "id": "upsell-stepper",
+          "type": "upsell",
+          "order": 2,
+          "label": "Post-purchase upsell",
+          "template": "src/demeter/upsell-bundle-stepper.html",
+          "page_url": "/upsell-stepper/",
+          "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "role": "upsell",
+              "ref_id": 30,
+              "quantity": 1
+            }
+          ],
+          "offers": [
+            {
+              "code": "UP50",
+              "package_ref_id": 30
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "demeter",
+            "frontmatter": {
+              "upsell_offer.package_id": 30,
+              "upsell_offer.vouchers_json": "[\"UP50\"]",
+              "upsell_bundle_tiers[].items_json": "[{\"packageId\":30,\"quantity\":1}]"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 3,
+          "label": "Receipt",
+          "template": "src/demeter/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "demeter",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/limos-single-offer-quantity.json
+++ b/docs/fixtures/campaign-specs/limos-single-offer-quantity.json
@@ -1,0 +1,164 @@
+{
+  "campaign": {
+    "id": "fixture-limos-single-offer",
+    "name": "Fixture Limos Single Offer Quantity",
+    "slug": "fixture-limos",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Limos Single Offer Quantity",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-limos-single-offer-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 1,
+          "label": "Checkout",
+          "template": "src/limos/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1
+            },
+            {
+              "role": "prepurchase_1",
+              "ref_id": 17,
+              "quantity": 1
+            },
+            {
+              "role": "prepurchase_2",
+              "ref_id": 19,
+              "quantity": 1
+            }
+          ],
+          "shipping_methods": [
+            "standard"
+          ],
+          "sdk_hints": {
+            "template_family": "limos",
+            "frontmatter": {
+              "packages.main_package": 10,
+              "packages.prepurchase_1": 17,
+              "packages.prepurchase_2": 19,
+              "shipping_methods.standard": 20,
+              "single_offer.package_id": 10,
+              "single_offer.shipping_method": "standard",
+              "single_offer.quantity_min": 1,
+              "single_offer.quantity_max": 5
+            }
+          }
+        },
+        {
+          "id": "upsell-stepper",
+          "type": "upsell",
+          "order": 2,
+          "label": "Post-purchase upsell",
+          "template": "src/limos/upsell-bundle-stepper.html",
+          "page_url": "/upsell-stepper/",
+          "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "role": "upsell",
+              "ref_id": 30,
+              "quantity": 1
+            }
+          ],
+          "offers": [
+            {
+              "code": "UP50",
+              "package_ref_id": 30
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "limos",
+            "frontmatter": {
+              "upsell_offer.package_id": 30,
+              "upsell_offer.vouchers_json": "[\"UP50\"]",
+              "upsell_bundle_tiers[].items_json": "[{\"packageId\":30,\"quantity\":1}]"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 3,
+          "label": "Receipt",
+          "template": "src/limos/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "limos",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json
+++ b/docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json
@@ -1,0 +1,149 @@
+{
+  "campaign": {
+    "id": "fixture-olympus-mv-single",
+    "name": "Fixture Olympus MV Single Step Configurable",
+    "slug": "fixture-olympus-mv-single",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Olympus MV Single Step Configurable",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-olympus-mv-single-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 1,
+          "label": "Checkout",
+          "template": "src/olympus-mv-single-step/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1,
+              "configurable": true
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 2,
+              "configurable": true
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 3,
+              "configurable": true
+            }
+          ],
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "olympus-mv-single-step",
+            "frontmatter": {
+              "packages.main_package": 10,
+              "shipping_methods.standard": 20,
+              "shipping_methods.free": 21,
+              "variant_slots": [
+                {
+                  "id": "buy1",
+                  "quantity": 1,
+                  "shipping_method": "standard",
+                  "selected": true
+                },
+                {
+                  "id": "buy2",
+                  "quantity": 2,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "buy3",
+                  "quantity": 3,
+                  "shipping_method": "free"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 2,
+          "label": "Receipt",
+          "template": "src/olympus-mv-single-step/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "olympus-mv-single-step",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json
+++ b/docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json
@@ -1,0 +1,165 @@
+{
+  "campaign": {
+    "id": "fixture-olympus-mv-two",
+    "name": "Fixture Olympus MV Two Step Configurable",
+    "slug": "fixture-olympus-mv-two",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Olympus MV Two Step Configurable",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-olympus-mv-two-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "select",
+          "type": "product",
+          "order": 1,
+          "label": "Select bundle and variants",
+          "template": "src/olympus-mv-two-step/select.html",
+          "page_url": "/select/",
+          "next_page": "checkout.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1,
+              "configurable": true
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 2,
+              "configurable": true
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 3,
+              "configurable": true
+            }
+          ],
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "olympus-mv-two-step",
+            "frontmatter": {
+              "packages.main_package": 10,
+              "shipping_methods.standard": 20,
+              "shipping_methods.free": 21,
+              "select_step.selector_id": "main",
+              "variant_slots": [
+                {
+                  "id": "buy1",
+                  "quantity": 1,
+                  "shipping_method": "standard",
+                  "selected": true
+                },
+                {
+                  "id": "buy2",
+                  "quantity": 2,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "buy3",
+                  "quantity": 3,
+                  "shipping_method": "free"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 2,
+          "label": "Checkout",
+          "template": "src/olympus-mv-two-step/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "receipt.html",
+          "sdk_hints": {
+            "template_family": "olympus-mv-two-step",
+            "frontmatter": {
+              "checkout_step.selector_id": "main"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 3,
+          "label": "Receipt",
+          "template": "src/olympus-mv-two-step/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "olympus-mv-two-step",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/olympus-tiered-standard-free.json
+++ b/docs/fixtures/campaign-specs/olympus-tiered-standard-free.json
@@ -1,0 +1,189 @@
+{
+  "campaign": {
+    "id": "fixture-olympus-tiered",
+    "name": "Fixture Olympus Tiered Standard Free",
+    "slug": "fixture-olympus",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Olympus Tiered Standard Free",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-olympus-tiered-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 1,
+          "label": "Checkout",
+          "template": "src/olympus/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 2
+            },
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 3
+            },
+            {
+              "role": "prepurchase_1",
+              "ref_id": 17,
+              "quantity": 1
+            },
+            {
+              "role": "prepurchase_2",
+              "ref_id": 19,
+              "quantity": 1
+            }
+          ],
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "olympus",
+            "frontmatter": {
+              "packages.main_package": 10,
+              "packages.prepurchase_1": 17,
+              "packages.prepurchase_2": 19,
+              "shipping_methods.standard": 20,
+              "shipping_methods.free": 21,
+              "bundles": [
+                {
+                  "id": "bundle-1x",
+                  "quantity": 1,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "bundle-2x",
+                  "quantity": 2,
+                  "shipping_method": "standard"
+                },
+                {
+                  "id": "bundle-3x",
+                  "quantity": 3,
+                  "shipping_method": "free"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "id": "upsell-stepper",
+          "type": "upsell",
+          "order": 2,
+          "label": "Post-purchase upsell",
+          "template": "src/olympus/upsell-bundle-stepper.html",
+          "page_url": "/upsell-stepper/",
+          "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "role": "upsell",
+              "ref_id": 30,
+              "quantity": 1
+            }
+          ],
+          "offers": [
+            {
+              "code": "UP50",
+              "package_ref_id": 30
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "olympus",
+            "frontmatter": {
+              "upsell_offer.package_id": 30,
+              "upsell_offer.vouchers_json": "[\"UP50\"]",
+              "upsell_bundle_tiers[].items_json": "[{\"packageId\":30,\"quantity\":1}]"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 3,
+          "label": "Receipt",
+          "template": "src/olympus/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "olympus",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json
+++ b/docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json
@@ -1,0 +1,156 @@
+{
+  "campaign": {
+    "id": "fixture-shop-single-step",
+    "name": "Fixture Shop Single Step Upsell Receipt",
+    "slug": "fixture-shop-single",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Shop Single Step Upsell Receipt",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-shop-single-step-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "checkout",
+          "type": "checkout",
+          "order": 1,
+          "label": "Checkout",
+          "template": "src/shop-single-step/checkout.html",
+          "page_url": "/checkout/",
+          "next_page": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1
+            },
+            {
+              "role": "order_bump",
+              "ref_id": 17,
+              "quantity": 1
+            }
+          ],
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "shop-single-step",
+            "frontmatter": {
+              "payment_flags.show_paypal": true,
+              "payment_flags.show_klarna": true,
+              "payment_flags.show_apple_pay": true,
+              "payment_flags.show_google_pay": true
+            }
+          }
+        },
+        {
+          "id": "upsell-stepper",
+          "type": "upsell",
+          "order": 2,
+          "label": "Post-purchase upsell",
+          "template": "src/shop-single-step/upsell-bundle-stepper.html",
+          "page_url": "/upsell-stepper/",
+          "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "role": "upsell",
+              "ref_id": 30,
+              "quantity": 1
+            }
+          ],
+          "offers": [
+            {
+              "code": "UP50",
+              "package_ref_id": 30
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "shop-single-step",
+            "frontmatter": {
+              "upsell_offer.package_id": 30,
+              "upsell_offer.vouchers_json": "[\"UP50\"]",
+              "upsell_bundle_tiers[].items_json": "[{\"packageId\":30,\"quantity\":1}]"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 3,
+          "label": "Receipt",
+          "template": "src/shop-single-step/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "shop-single-step",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json
+++ b/docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json
@@ -1,0 +1,179 @@
+{
+  "campaign": {
+    "id": "fixture-shop-three-step",
+    "name": "Fixture Shop Three Step Dynamic Shipping",
+    "slug": "fixture-shop-three",
+    "currency": "USD",
+    "language": "en",
+    "payment_env_key": "fixture_payment_env_key",
+    "tracking": {
+      "status": "not_configured"
+    },
+    "footer_links": [
+      {
+        "label": "Privacy Policy",
+        "url": "https://example.com/privacy",
+        "required": true
+      },
+      {
+        "label": "Terms of Service",
+        "url": "https://example.com/terms",
+        "required": true
+      },
+      {
+        "label": "Contact Us",
+        "url": "https://example.com/contact",
+        "required": true
+      }
+    ],
+    "seo": {
+      "required": false,
+      "title": "Fixture Shop Three Step Dynamic Shipping",
+      "description": "Agent contract fixture. Replace with campaign-specific metadata when required."
+    }
+  },
+  "spec_identity": {
+    "map_id": "fixture-shop-three-step-map",
+    "source": "campaign-cart-starter-templates agent fixture"
+  },
+  "funnels": [
+    {
+      "id": "default",
+      "name": "Default",
+      "hypothesis": "Fixture only: demonstrate the template family contract for agent builds.",
+      "weight": 100,
+      "pages": [
+        {
+          "id": "information",
+          "type": "checkout",
+          "order": 1,
+          "label": "Information",
+          "template": "src/shop-three-step/information.html",
+          "page_url": "/information/",
+          "next_page": "shipping.html",
+          "packages": [
+            {
+              "role": "main",
+              "ref_id": 10,
+              "quantity": 1
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "shop-three-step",
+            "frontmatter": {
+              "next_url": "shipping.html"
+            }
+          }
+        },
+        {
+          "id": "shipping",
+          "type": "checkout",
+          "order": 2,
+          "label": "Shipping",
+          "template": "src/shop-three-step/shipping.html",
+          "page_url": "/shipping/",
+          "next_page": "billing.html",
+          "shipping_methods": [
+            "standard",
+            "free"
+          ],
+          "sdk_hints": {
+            "template_family": "shop-three-step",
+            "frontmatter": {
+              "next_url": "billing.html",
+              "runtime_shipping_source": "window.next.getShippingMethods()"
+            }
+          }
+        },
+        {
+          "id": "billing",
+          "type": "checkout",
+          "order": 3,
+          "label": "Billing",
+          "template": "src/shop-three-step/billing.html",
+          "page_url": "/billing/",
+          "next_page": "upsell-bundle-stepper.html",
+          "sdk_hints": {
+            "template_family": "shop-three-step",
+            "frontmatter": {
+              "next_url": "upsell-bundle-stepper.html"
+            }
+          }
+        },
+        {
+          "id": "upsell-stepper",
+          "type": "upsell",
+          "order": 4,
+          "label": "Post-purchase upsell",
+          "template": "src/shop-three-step/upsell-bundle-stepper.html",
+          "page_url": "/upsell-stepper/",
+          "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "role": "upsell",
+              "ref_id": 30,
+              "quantity": 1
+            }
+          ],
+          "offers": [
+            {
+              "code": "UP50",
+              "package_ref_id": 30
+            }
+          ],
+          "sdk_hints": {
+            "template_family": "shop-three-step",
+            "frontmatter": {
+              "upsell_offer.package_id": 30,
+              "upsell_offer.vouchers_json": "[\"UP50\"]",
+              "upsell_bundle_tiers[].items_json": "[{\"packageId\":30,\"quantity\":1}]"
+            }
+          }
+        },
+        {
+          "id": "receipt",
+          "type": "thankyou",
+          "order": 5,
+          "label": "Receipt",
+          "template": "src/shop-three-step/receipt.html",
+          "page_url": "/receipt/",
+          "sdk_hints": {
+            "template_family": "shop-three-step",
+            "frontmatter": {
+              "receipt_summary.title": "Order Summary",
+              "receipt_summary.mobile_item_template_id": "order-item-template-mobile",
+              "receipt_summary.desktop_item_template_id": "order-item-template-desktop"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "shipping_methods": [
+    {
+      "key": "standard",
+      "ref_id": 20,
+      "name": "Standard Shipping",
+      "price": "4.95"
+    },
+    {
+      "key": "free",
+      "ref_id": 21,
+      "name": "Free Shipping",
+      "price": "0.00"
+    }
+  ],
+  "offers": [
+    {
+      "code": "UP50",
+      "package_ref_id": 30,
+      "discount_type": "percent",
+      "value": 50,
+      "applies_to": [
+        "upsell"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:sdk:promoted:source": "node scripts/lint-sdk.mjs --source --scope=promoted --pages=checkout,select",
     "lint:sdk:promoted:rendered": "node scripts/lint-sdk.mjs --rendered --scope=promoted --pages=checkout,select",
     "lint:sdk:shop-single-step:all": "node scripts/lint-sdk.mjs --scope=shop-single-step --pages=all",
-    "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=checkout,select"
+    "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=checkout,select",
+    "lint:agent-contracts": "node scripts/lint-agent-contracts.mjs"
   },
   "dependencies": {
     "next-campaign-page-kit": "^0.1.0"

--- a/scripts/lint-agent-contracts.mjs
+++ b/scripts/lint-agent-contracts.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// lint-agent-contracts.mjs
+//
+// Validates the machine-readable agent contract layer that sits beside the
+// template runtime. This is not a campaign readiness gate: it only checks that
+// the catalog and CampaignSpec-shaped fixtures stay coherent.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const repoRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const catalogPath = join(repoRoot, 'docs/commerce-surface-catalog.json');
+const expectedFamilies = [
+  'olympus',
+  'limos',
+  'demeter',
+  'shop-single-step',
+  'shop-three-step',
+  'olympus-mv-single-step',
+  'olympus-mv-two-step',
+];
+
+const errors = [];
+const warnings = [];
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    errors.push(`${relative(repoRoot, path)}: invalid JSON (${error.message})`);
+    return null;
+  }
+}
+
+function hasPath(obj, dotted) {
+  const parts = dotted.split('.');
+  let cur = obj;
+  for (const part of parts) {
+    if (part.endsWith('[]')) {
+      const key = part.slice(0, -2);
+      if (!Array.isArray(cur?.[key])) return false;
+      cur = cur[key][0];
+      continue;
+    }
+    if (cur == null || !(part in cur)) return false;
+    cur = cur[part];
+  }
+  return true;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${label}: expected a non-empty array`);
+    return false;
+  }
+  return true;
+}
+
+const catalog = readJson(catalogPath);
+if (!catalog) process.exit(1);
+
+if (catalog.agentContractVersion !== 1) {
+  errors.push('docs/commerce-surface-catalog.json: agentContractVersion must be 1');
+}
+
+if (!catalog.sharedFrontmatterVocabulary || typeof catalog.sharedFrontmatterVocabulary !== 'object') {
+  errors.push('docs/commerce-surface-catalog.json: missing sharedFrontmatterVocabulary');
+}
+
+for (const family of expectedFamilies) {
+  const srcDir = join(repoRoot, 'src', family);
+  if (!existsSync(srcDir) || !statSync(srcDir).isDirectory()) {
+    errors.push(`src/${family}: expected template family directory`);
+  }
+
+  const entry = catalog.families?.[family];
+  if (!entry) {
+    errors.push(`catalog.families.${family}: missing family entry`);
+    continue;
+  }
+
+  const contract = entry.agentContract;
+  if (!contract) {
+    errors.push(`catalog.families.${family}.agentContract: missing agent contract`);
+    continue;
+  }
+
+  for (const key of ['templateRole', 'sourceOfTruth', 'frontmatter', 'surfaces', 'fixtures', 'agentNotes']) {
+    if (!(key in contract)) errors.push(`catalog.families.${family}.agentContract.${key}: missing`);
+  }
+
+  requireArray(contract.fixtures, `catalog.families.${family}.agentContract.fixtures`);
+  requireArray(contract.surfaces, `catalog.families.${family}.agentContract.surfaces`);
+
+  for (const fixture of contract.fixtures || []) {
+    const fixturePath = join(repoRoot, fixture);
+    if (!existsSync(fixturePath)) {
+      errors.push(`${fixture}: referenced fixture does not exist`);
+      continue;
+    }
+    const spec = readJson(fixturePath);
+    if (!spec) continue;
+    validateFixture(spec, fixturePath, family);
+  }
+}
+
+function validateFixture(spec, fixturePath, family) {
+  const label = relative(repoRoot, fixturePath);
+  for (const required of ['campaign.id', 'campaign.name', 'campaign.currency', 'campaign.language', 'funnels[]']) {
+    if (!hasPath(spec, required)) errors.push(`${label}: missing ${required}`);
+  }
+
+  if (!Array.isArray(spec.funnels)) return;
+  for (const [funnelIndex, funnel] of spec.funnels.entries()) {
+    if (!Array.isArray(funnel.pages) || funnel.pages.length === 0) {
+      errors.push(`${label}: funnels[${funnelIndex}].pages must be a non-empty array`);
+      continue;
+    }
+    for (const [pageIndex, page] of funnel.pages.entries()) {
+      for (const required of ['id', 'type', 'order', 'label']) {
+        if (!(required in page)) {
+          errors.push(`${label}: funnels[${funnelIndex}].pages[${pageIndex}] missing ${required}`);
+        }
+      }
+      if (page.sdk_hints?.template_family && page.sdk_hints.template_family !== family) {
+        errors.push(
+          `${label}: page ${page.id || pageIndex} sdk_hints.template_family=${page.sdk_hints.template_family} does not match catalog family ${family}`
+        );
+      }
+      if (page.template && !existsSync(join(repoRoot, page.template))) {
+        warnings.push(`${label}: page ${page.id || pageIndex} template path ${page.template} does not exist`);
+      }
+    }
+  }
+}
+
+if (warnings.length) {
+  console.log(`[lint-agent-contracts] ${warnings.length} warning(s):`);
+  for (const warning of warnings) console.log(`  - ${warning}`);
+}
+
+if (errors.length) {
+  console.log(`[lint-agent-contracts] FAIL - ${errors.length} error(s):`);
+  for (const error of errors) console.log(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log('[lint-agent-contracts] PASS');


### PR DESCRIPTION
## Summary
- extend the commerce surface catalog to v2 with per-family agentContract blocks and shared frontmatter vocabulary
- add CampaignSpec-shaped fixtures for all first-class checkout families, including shop-three-step dynamic shipping
- add npm run lint:agent-contracts to keep catalog/fixture shape coherent without making this a live campaign readiness gate

## Notes for review
- This is commensurate with the existing campaign runtime as a contract layer beside campaign-build/lint-sdk, not a replacement for runtime validation.
- The PR intentionally does not introduce a real CampaignSpec/API readiness check yet. It documents the shape that such a check can later consume.
- shop-three-step is now explicitly cataloged as partial-needs-promotion because shipping is dynamic from sdk.getShippingMethods(), while upsell/receipt parity still needs a focused follow-up.

## Validation
- npm run lint:agent-contracts
- npm run build
- npm run lint:sdk
- npm run lint:sdk:promoted
- npm run lint:sdk:ci
- npm run lint:sdk:shop-single-step:all
- node scripts/lint-sdk.mjs --scope=limos --pages=all
- node scripts/lint-sdk.mjs --scope=demeter --pages=all