### PR TITLE
Flag market-sensitive starter copy

### DIFF
--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -82,6 +82,8 @@ For each first-class family, read `families[family].agentContract` in the JSON c
 
 The fixtures in `docs/fixtures/campaign-specs/` are examples, not live Campaigns App exports. Use their `sdk_hints.frontmatter` blocks to understand the mapping, then replace every numeric `ref_id` from the target CampaignSpec/API.
 
+Market-sensitive starter copy is also a contract surface. If the campaign is country-specific or multi-market, or if the CampaignSpec declares additional currencies, non-US shipping countries, or `available_shipping_countries: "all"`, scan visible copy for US-only assumptions such as `USPS`, `ships from the USA`, `US warehouse`, `contiguous US`, `All US orders ship free`, `Made in USA`, `manufactured in the USA`, `State`, and `ZIP Code`. Treat matches as replace-or-confirm campaign copy. Warn and preserve only when the CampaignSpec, source design, or operator confirms the claim; do not remove them automatically.
+
 ---
 
 ## Read the SDK docs first

--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -21,6 +21,58 @@
       "class-name fingerprints"
     ]
   },
+  "copyReviewPolicy": {
+    "purpose": "Market-sensitive starter copy must be confirmed against the target campaign instead of blindly carried forward or automatically removed.",
+    "appliesWhen": [
+      "CampaignSpec declares additional currencies",
+      "CampaignSpec declares non-US shipping countries",
+      "CampaignSpec available_shipping_countries is all",
+      "builder records market mode as country-specific or multi-market"
+    ],
+    "reviewSurfaces": [
+      "landing and presell page copy",
+      "checkout trust and delivery copy",
+      "upsell shipping info blocks",
+      "receipt/support copy",
+      "visible carrier, warehouse, and manufacturing claims"
+    ],
+    "warnOnlyPatterns": [
+      {
+        "label": "US carrier or warehouse claim",
+        "examples": [
+          "USPS",
+          "ships from the USA",
+          "US warehouse",
+          "contiguous US"
+        ]
+      },
+      {
+        "label": "US shipping promise",
+        "examples": [
+          "All US orders ship free",
+          "USA only",
+          "United States only",
+          "free shipping on all US orders"
+        ]
+      },
+      {
+        "label": "US manufacturing or compliance claim",
+        "examples": [
+          "Made in USA",
+          "manufactured in the USA",
+          "FDA-registered US facility"
+        ]
+      },
+      {
+        "label": "US address-language assumption",
+        "examples": [
+          "State",
+          "ZIP Code"
+        ]
+      }
+    ],
+    "agentRule": "When a warn-only pattern appears in a country-specific or multi-market campaign, treat it as replace-or-confirm campaign copy. Preserve it only when the CampaignSpec, source design, or operator explicitly confirms the claim. Do not remove it automatically."
+  },
   "sharedFrontmatterVocabulary": {
     "packages": {
       "purpose": "Named Campaigns App package ref_ids used by checkout selectors, bumps, and display bindings.",

--- a/docs/commerce-surface-catalog.md
+++ b/docs/commerce-surface-catalog.md
@@ -51,6 +51,14 @@ The important boundary is: CampaignSpec/API owns package refs, shipping refs, vo
 
 Catalog component names should be generic by default. Use names like `upsell-bundle-stepper-offer`, `upsell-bundle-tier-pills-offer`, and `upsell-bundle-tier-cards-offer` when the SDK attributes and frontmatter contract are shared across families. Reserve family-specific names for surfaces with genuinely different SDK ownership or frontmatter contracts, such as MV configurable upsells.
 
+## Market-Sensitive Copy Review
+
+Starter templates include demo copy for shipping, carrier, warehouse, address, and manufacturing claims. Treat those claims as replace-or-confirm campaign copy when the CampaignSpec declares additional currencies, non-US shipping countries, `available_shipping_countries: "all"`, or the builder records the campaign as country-specific or multi-market.
+
+This is a warning contract, not an automatic removal rule. Some global campaigns really do ship from a US warehouse or manufacture in the USA. Preserve those claims only when the CampaignSpec, source design, or operator explicitly confirms them.
+
+Warn on obvious market-sensitive patterns such as `USPS`, `ships from the USA`, `US warehouse`, `contiguous US`, `All US orders ship free`, `Made in USA`, `manufactured in the USA`, `State`, and `ZIP Code`.
+
 ## Fixture Specs
 
 Each first-class checkout family has a small CampaignSpec-shaped fixture:


### PR DESCRIPTION
## Summary
- add a copyReviewPolicy contract for market-sensitive starter copy
- document US-specific shipping/manufacturing/address copy as replace-or-confirm, not automatic removal
- add the rule to the agent template context

## Checks
- npm run lint:agent-contracts
- git diff --check