### PR TITLE
[codex] Add starter template asset hygiene lint

### DIFF
--- a/scripts/lint-agent-contracts.mjs
+++ b/scripts/lint-agent-contracts.mjs
@@ -6,7 +6,7 @@
 // the catalog and CampaignSpec-shaped fixtures stay coherent.
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { extname, join, relative } from 'node:path';
 
 const repoRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const catalogPath = join(repoRoot, 'docs/commerce-surface-catalog.json');
@@ -91,6 +91,7 @@ for (const family of expectedFamilies) {
 
   requireArray(contract.fixtures, `catalog.families.${family}.agentContract.fixtures`);
   requireArray(contract.surfaces, `catalog.families.${family}.agentContract.surfaces`);
+  validateFamilyAssetReferences(family, srcDir);
 
   for (const fixture of contract.fixtures || []) {
     const fixturePath = join(repoRoot, fixture);
@@ -101,6 +102,34 @@ for (const family of expectedFamilies) {
     const spec = readJson(fixturePath);
     if (!spec) continue;
     validateFixture(spec, fixturePath, family);
+  }
+}
+
+function walkFiles(dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(path, files);
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function validateFamilyAssetReferences(family, srcDir) {
+  const assetPattern = /(['"])([^'"]+)\1\s*\|\s*campaign_asset/g;
+  for (const file of walkFiles(srcDir)) {
+    if (!['.html', '.css', '.js'].includes(extname(file))) continue;
+    const content = readFileSync(file, 'utf8');
+    for (const match of content.matchAll(assetPattern)) {
+      const assetPath = match[2];
+      if (/^(?:https?:)?\/\//.test(assetPath) || assetPath.startsWith('/')) continue;
+      const fullPath = join(srcDir, 'assets', assetPath);
+      if (!existsSync(fullPath)) {
+        errors.push(`${relative(repoRoot, file)}: campaign_asset reference "${assetPath}" does not exist under src/${family}/assets/`);
+      }
+    }
   }
 }
 

--- a/src/demeter/assets/images/credit-card-flags.svg
+++ b/src/demeter/assets/images/credit-card-flags.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="24" viewBox="0 0 168 24" role="img" aria-label="Accepted card brands">
+  <rect width="168" height="24" rx="4" fill="#f6f7f9"/>
+  <g transform="translate(6 4)">
+    <rect width="34" height="16" rx="2" fill="#1a1f71"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">VISA</text>
+  </g>
+  <g transform="translate(46 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="14" cy="8" r="6" fill="#eb001b"/>
+    <circle cx="20" cy="8" r="6" fill="#f79e1b" fill-opacity=".9"/>
+  </g>
+  <g transform="translate(86 4)">
+    <rect width="34" height="16" rx="2" fill="#2e77bc"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">AMEX</text>
+  </g>
+  <g transform="translate(126 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="17" cy="8" r="6" fill="#f58220"/>
+    <text x="17" y="11" text-anchor="middle" font-family="Arial, sans-serif" font-size="6" font-weight="700" fill="#111">DISC</text>
+  </g>
+</svg>

--- a/src/demeter/assets/images/icon.svg
+++ b/src/demeter/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/limos/assets/images/icon.svg
+++ b/src/limos/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/olympus-mv-single-step/assets/images/credit-card-flags.svg
+++ b/src/olympus-mv-single-step/assets/images/credit-card-flags.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="24" viewBox="0 0 168 24" role="img" aria-label="Accepted card brands">
+  <rect width="168" height="24" rx="4" fill="#f6f7f9"/>
+  <g transform="translate(6 4)">
+    <rect width="34" height="16" rx="2" fill="#1a1f71"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">VISA</text>
+  </g>
+  <g transform="translate(46 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="14" cy="8" r="6" fill="#eb001b"/>
+    <circle cx="20" cy="8" r="6" fill="#f79e1b" fill-opacity=".9"/>
+  </g>
+  <g transform="translate(86 4)">
+    <rect width="34" height="16" rx="2" fill="#2e77bc"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">AMEX</text>
+  </g>
+  <g transform="translate(126 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="17" cy="8" r="6" fill="#f58220"/>
+    <text x="17" y="11" text-anchor="middle" font-family="Arial, sans-serif" font-size="6" font-weight="700" fill="#111">DISC</text>
+  </g>
+</svg>

--- a/src/olympus-mv-single-step/assets/images/icon.svg
+++ b/src/olympus-mv-single-step/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/olympus-mv-two-step/assets/images/credit-card-flags.svg
+++ b/src/olympus-mv-two-step/assets/images/credit-card-flags.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="24" viewBox="0 0 168 24" role="img" aria-label="Accepted card brands">
+  <rect width="168" height="24" rx="4" fill="#f6f7f9"/>
+  <g transform="translate(6 4)">
+    <rect width="34" height="16" rx="2" fill="#1a1f71"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">VISA</text>
+  </g>
+  <g transform="translate(46 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="14" cy="8" r="6" fill="#eb001b"/>
+    <circle cx="20" cy="8" r="6" fill="#f79e1b" fill-opacity=".9"/>
+  </g>
+  <g transform="translate(86 4)">
+    <rect width="34" height="16" rx="2" fill="#2e77bc"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">AMEX</text>
+  </g>
+  <g transform="translate(126 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="17" cy="8" r="6" fill="#f58220"/>
+    <text x="17" y="11" text-anchor="middle" font-family="Arial, sans-serif" font-size="6" font-weight="700" fill="#111">DISC</text>
+  </g>
+</svg>

--- a/src/olympus-mv-two-step/assets/images/icon.svg
+++ b/src/olympus-mv-two-step/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/olympus/assets/images/credit-card-flags.svg
+++ b/src/olympus/assets/images/credit-card-flags.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="24" viewBox="0 0 168 24" role="img" aria-label="Accepted card brands">
+  <rect width="168" height="24" rx="4" fill="#f6f7f9"/>
+  <g transform="translate(6 4)">
+    <rect width="34" height="16" rx="2" fill="#1a1f71"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">VISA</text>
+  </g>
+  <g transform="translate(46 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="14" cy="8" r="6" fill="#eb001b"/>
+    <circle cx="20" cy="8" r="6" fill="#f79e1b" fill-opacity=".9"/>
+  </g>
+  <g transform="translate(86 4)">
+    <rect width="34" height="16" rx="2" fill="#2e77bc"/>
+    <text x="17" y="11.5" text-anchor="middle" font-family="Arial, sans-serif" font-size="7" font-weight="700" fill="#fff">AMEX</text>
+  </g>
+  <g transform="translate(126 4)">
+    <rect width="34" height="16" rx="2" fill="#fff" stroke="#d9dde5"/>
+    <circle cx="17" cy="8" r="6" fill="#f58220"/>
+    <text x="17" y="11" text-anchor="middle" font-family="Arial, sans-serif" font-size="6" font-weight="700" fill="#111">DISC</text>
+  </g>
+</svg>

--- a/src/olympus/assets/images/icon.svg
+++ b/src/olympus/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shop-single-step/assets/images/icon.svg
+++ b/src/shop-single-step/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shop-three-step/assets/images/icon.svg
+++ b/src/shop-three-step/assets/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+  <circle cx="10" cy="10" r="10" fill="#16a34a"/>
+  <path d="M5.5 10.2 8.4 13l6.1-6" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds `campaign_asset` reference validation to `scripts/lint-agent-contracts.mjs` so starter families fail lint when template HTML/CSS/JS points at missing local assets.
- Adds the missing `credit-card-flags.svg` assets for checkout families that reference them.
- Adds small fallback `icon.svg` assets for families that reference `images/icon.svg` through existing templates/fixtures.

## Why

This ties back to Linear SELL-271, Home Outage Prep Campaigns OS dogfood #2. The dogfood found that the Demeter starter referenced `images/credit-card-flags.svg` but did not ship the asset, producing a 404 that QA did not catch. This PR turns that class of problem into template lint coverage.

## Validation

- `npm run lint:agent-contracts` passed.
- `git diff --check` passed.
- Removed a stray patch hunk from one generated SVG before committing.