### PR TITLE
Harden non-Olympus receipt + shop-three-step SDK partials; widen lint CI to all-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:sdk:promoted:source": "node scripts/lint-sdk.mjs --source --scope=promoted --pages=checkout,select,upsell-bundle-stepper,upsell-bundle-tier-pills,upsell-bundle-tier-cards,upsell-mv",
     "lint:sdk:promoted:rendered": "node scripts/lint-sdk.mjs --rendered --scope=promoted --pages=checkout,select,upsell-bundle-stepper,upsell-bundle-tier-pills,upsell-bundle-tier-cards,upsell-mv",
     "lint:sdk:shop-single-step:all": "node scripts/lint-sdk.mjs --scope=shop-single-step --pages=all",
-    "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=checkout,select",
+    "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=all",
+    "lint:sdk:promoted:all": "node scripts/lint-sdk.mjs --scope=promoted --pages=all",
     "lint:agent-contracts": "node scripts/lint-agent-contracts.mjs"
   },
   "dependencies": {

--- a/src/olympus-mv-single-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-single-step/_includes/receipt-orders.html
@@ -1,0 +1,67 @@
+{% comment %}
+  next_component: receipt-orders
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
+  next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
+  next_sdk_owns:
+    - data-next-order-items
+    - data-item-template-id (must match the inner <template id>)
+    - data-next-hide="cart.isEmpty"
+    - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
+  next_theming:
+    classes_designer_owns: [.cart-items, .cart-items__list, .cart-items__scroll-hint, .cart-item, .cart-item__wrapper, .cart-item__image-container, .cart-item__quantity-badge, .cart-item__quantity, .cart-item__image, .cart-item__details, .cart-item__content, .cart-item__description, .cart-item__header, .cart-item__title, .cart-item__pricing, .checkout__line-item__final-price]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
+    - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
+    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+  next_gotchas:
+    - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
+  next_variants:
+    - default (this)
+  next_related:
+    - receipt-skeleton (loading skeleton this replaces once SDK hydrates)
+    - cart-summary01..04 (checkout-time order summary; different SDK contract via data-next-cart-summary)
+{% endcomment %}
+<div data-next-catalog-component="receipt-orders" class="cart-items">
+  <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
+    <div>Scroll for more items</div>
+    <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
+      </svg></div>
+  </div>
+  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+      <div data-order-line-id="{item.id}" class="cart-item">
+        <div class="cart-item__wrapper">
+          <div class="cart-item__image-container">
+            <div class="cart-item__quantity-badge">
+              <div class="cart-item__quantity">{item.quantity}</div>
+            </div><img src="{item.image}" class="cart-item__image">
+          </div>
+          <div class="cart-item__details">
+            <div class="cart-item__content">
+              <div class="cart-item__description">
+                <div class="cart-item__header">
+                  <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
+                </div>
+                <div class="quantity-controls hide">
+                  <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
+                    <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
+                    <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
+                    <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
+                  </div>
+                </div>
+              </div>
+              <div class="cart-item__pricing">
+                <div class="checkout__line-item__final-price">{item.lineTotal}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
+  </div>
+</div>

--- a/src/olympus-mv-single-step/_includes/receipt-skeleton.html
+++ b/src/olympus-mv-single-step/_includes/receipt-skeleton.html
@@ -1,4 +1,4 @@
-<div data-next-skeleton="" class="skeleton-wrapper">
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/olympus-mv-single-step/receipt.html
+++ b/src/olympus-mv-single-step/receipt.html
@@ -32,46 +32,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">
@@ -207,46 +168,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title checkout">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">

--- a/src/olympus-mv-two-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-two-step/_includes/receipt-orders.html
@@ -1,0 +1,67 @@
+{% comment %}
+  next_component: receipt-orders
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
+  next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
+  next_sdk_owns:
+    - data-next-order-items
+    - data-item-template-id (must match the inner <template id>)
+    - data-next-hide="cart.isEmpty"
+    - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
+  next_theming:
+    classes_designer_owns: [.cart-items, .cart-items__list, .cart-items__scroll-hint, .cart-item, .cart-item__wrapper, .cart-item__image-container, .cart-item__quantity-badge, .cart-item__quantity, .cart-item__image, .cart-item__details, .cart-item__content, .cart-item__description, .cart-item__header, .cart-item__title, .cart-item__pricing, .checkout__line-item__final-price]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
+    - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
+    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+  next_gotchas:
+    - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
+  next_variants:
+    - default (this)
+  next_related:
+    - receipt-skeleton (loading skeleton this replaces once SDK hydrates)
+    - cart-summary01..04 (checkout-time order summary; different SDK contract via data-next-cart-summary)
+{% endcomment %}
+<div data-next-catalog-component="receipt-orders" class="cart-items">
+  <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
+    <div>Scroll for more items</div>
+    <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
+      </svg></div>
+  </div>
+  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+      <div data-order-line-id="{item.id}" class="cart-item">
+        <div class="cart-item__wrapper">
+          <div class="cart-item__image-container">
+            <div class="cart-item__quantity-badge">
+              <div class="cart-item__quantity">{item.quantity}</div>
+            </div><img src="{item.image}" class="cart-item__image">
+          </div>
+          <div class="cart-item__details">
+            <div class="cart-item__content">
+              <div class="cart-item__description">
+                <div class="cart-item__header">
+                  <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
+                </div>
+                <div class="quantity-controls hide">
+                  <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
+                    <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
+                    <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
+                    <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
+                  </div>
+                </div>
+              </div>
+              <div class="cart-item__pricing">
+                <div class="checkout__line-item__final-price">{item.lineTotal}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
+  </div>
+</div>

--- a/src/olympus-mv-two-step/_includes/receipt-skeleton.html
+++ b/src/olympus-mv-two-step/_includes/receipt-skeleton.html
@@ -1,4 +1,4 @@
-<div data-next-skeleton="" class="skeleton-wrapper">
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/olympus-mv-two-step/receipt.html
+++ b/src/olympus-mv-two-step/receipt.html
@@ -32,46 +32,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">
@@ -207,46 +168,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title checkout">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">

--- a/src/olympus/_includes/receipt-orders.html
+++ b/src/olympus/_includes/receipt-orders.html
@@ -1,0 +1,67 @@
+{% comment %}
+  next_component: receipt-orders
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
+  next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
+  next_sdk_owns:
+    - data-next-order-items
+    - data-item-template-id (must match the inner <template id>)
+    - data-next-hide="cart.isEmpty"
+    - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
+  next_theming:
+    classes_designer_owns: [.cart-items, .cart-items__list, .cart-items__scroll-hint, .cart-item, .cart-item__wrapper, .cart-item__image-container, .cart-item__quantity-badge, .cart-item__quantity, .cart-item__image, .cart-item__details, .cart-item__content, .cart-item__description, .cart-item__header, .cart-item__title, .cart-item__pricing, .checkout__line-item__final-price]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
+    - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
+    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+  next_gotchas:
+    - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
+  next_variants:
+    - default (this)
+  next_related:
+    - receipt-skeleton (loading skeleton this replaces once SDK hydrates)
+    - cart-summary01..04 (checkout-time order summary; different SDK contract via data-next-cart-summary)
+{% endcomment %}
+<div data-next-catalog-component="receipt-orders" class="cart-items">
+  <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
+    <div>Scroll for more items</div>
+    <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
+      </svg></div>
+  </div>
+  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+      <div data-order-line-id="{item.id}" class="cart-item">
+        <div class="cart-item__wrapper">
+          <div class="cart-item__image-container">
+            <div class="cart-item__quantity-badge">
+              <div class="cart-item__quantity">{item.quantity}</div>
+            </div><img src="{item.image}" class="cart-item__image">
+          </div>
+          <div class="cart-item__details">
+            <div class="cart-item__content">
+              <div class="cart-item__description">
+                <div class="cart-item__header">
+                  <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
+                </div>
+                <div class="quantity-controls hide">
+                  <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
+                    <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
+                    <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
+                    <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
+                  </div>
+                </div>
+              </div>
+              <div class="cart-item__pricing">
+                <div class="checkout__line-item__final-price">{item.lineTotal}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
+  </div>
+</div>

--- a/src/olympus/receipt.html
+++ b/src/olympus/receipt.html
@@ -32,46 +32,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">
@@ -207,46 +168,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title checkout">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">

--- a/src/shop-three-step/_includes/bump-check02.html
+++ b/src/shop-three-step/_includes/bump-check02.html
@@ -1,7 +1,7 @@
 <!-- Prepurchase upsell: checkbox bump (check02) — SDK 0.4.x flat layout
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display + data-next-toggle-image
      Do not put Liquid tags inside HTML comments — Liquid still executes them. -->
-<div data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
+<div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="9" class="next-active">
       <div data-next-toggle="toggle" class="bump__header next-active">

--- a/src/shop-three-step/_includes/cart-summary04.html
+++ b/src/shop-three-step/_includes/cart-summary04.html
@@ -1,4 +1,4 @@
-<div class="summary-wrapper" data-next-cart-summary>
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <h4 class="order-summary__title">Order Summary</h4>

--- a/src/shop-three-step/_includes/express-checkout.html
+++ b/src/shop-three-step/_includes/express-checkout.html
@@ -1,4 +1,4 @@
-<div data-next-express-checkout="container" class="exp-checkout">
+<div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>
   {% endif %}

--- a/src/shop-three-step/_includes/payment-methods.html
+++ b/src/shop-three-step/_includes/payment-methods.html
@@ -1,4 +1,4 @@
-<div class="payment-methods">
+<div data-next-catalog-component="payment-method-presentation" class="payment-methods">
   <div data-next-payment-method="credit" class="payment-method next-selected">
     <div class="payment-method__header"><label for="combo_mode_credit" combo_mode="credit" class="payment-method__label"><input type="radio" name="payment_method" id="combo_mode_credit" data-name="Combo Mode" class="payment-method__input" checked="" value="credit">
         <div class="payment-method__title">Credit Card</div>

--- a/src/shop-three-step/_includes/receipt-orders.html
+++ b/src/shop-three-step/_includes/receipt-orders.html
@@ -1,0 +1,67 @@
+{% comment %}
+  next_component: receipt-orders
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
+  next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
+  next_sdk_owns:
+    - data-next-order-items
+    - data-item-template-id (must match the inner <template id>)
+    - data-next-hide="cart.isEmpty"
+    - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
+  next_theming:
+    classes_designer_owns: [.cart-items, .cart-items__list, .cart-items__scroll-hint, .cart-item, .cart-item__wrapper, .cart-item__image-container, .cart-item__quantity-badge, .cart-item__quantity, .cart-item__image, .cart-item__details, .cart-item__content, .cart-item__description, .cart-item__header, .cart-item__title, .cart-item__pricing, .checkout__line-item__final-price]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
+    - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
+    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+  next_gotchas:
+    - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
+  next_variants:
+    - default (this)
+  next_related:
+    - receipt-skeleton (loading skeleton this replaces once SDK hydrates)
+    - cart-summary01..04 (checkout-time order summary; different SDK contract via data-next-cart-summary)
+{% endcomment %}
+<div data-next-catalog-component="receipt-orders" class="cart-items">
+  <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
+    <div>Scroll for more items</div>
+    <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
+      </svg></div>
+  </div>
+  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+      <div data-order-line-id="{item.id}" class="cart-item">
+        <div class="cart-item__wrapper">
+          <div class="cart-item__image-container">
+            <div class="cart-item__quantity-badge">
+              <div class="cart-item__quantity">{item.quantity}</div>
+            </div><img src="{item.image}" class="cart-item__image">
+          </div>
+          <div class="cart-item__details">
+            <div class="cart-item__content">
+              <div class="cart-item__description">
+                <div class="cart-item__header">
+                  <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
+                </div>
+                <div class="quantity-controls hide">
+                  <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
+                    <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
+                    <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
+                    <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
+                  </div>
+                </div>
+              </div>
+              <div class="cart-item__pricing">
+                <div class="checkout__line-item__final-price">{item.lineTotal}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
+  </div>
+</div>

--- a/src/shop-three-step/_includes/receipt-skeleton.html
+++ b/src/shop-three-step/_includes/receipt-skeleton.html
@@ -1,4 +1,4 @@
-<div data-next-skeleton="" class="skeleton-wrapper">
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/shop-three-step/receipt.html
+++ b/src/shop-three-step/receipt.html
@@ -32,46 +32,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">
@@ -207,46 +168,7 @@ styles:
                         <div class="order-summary">
                           <h4 class="order-summary__title checkout">Order Summary</h4>
                           <div class="order-summary__content">
-                            <div class="cart-items">
-                              <div data-next-component="scroll-hint" class="cart-items__scroll-hint cart-items__scroll-hint--active">
-                                <div>Scroll for more items</div>
-                                <div class="icon__view-more"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ic" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                                    <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
-                                  </svg></div>
-                              </div>
-                              <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
-                                  <div data-order-line-id="{item.id}" class="cart-item">
-                                    <div class="cart-item__wrapper">
-                                      <div class="cart-item__image-container">
-                                        <div class="cart-item__quantity-badge">
-                                          <div class="cart-item__quantity">{item.quantity}</div>
-                                        </div><img src="{item.image}" class="cart-item__image">
-                                      </div>
-                                      <div class="cart-item__details">
-                                        <div class="cart-item__content">
-                                          <div class="cart-item__description">
-                                            <div class="cart-item__header">
-                                              <div pb-cart="line_item-title" class="cart-item__title">{item.name}</div>
-                                            </div>
-                                            <div class="quantity-controls hide">
-                                              <div id="quantity_-item.packageId" data-flavor="original" class="cart-quantity-controls__container">
-                                                <div data-package-id="{item.packageId}" data-next-quantity="decrease" role="button" class="quantity-controls__button quantity-controls__button--decrease">-</div>
-                                                <div pb-cart="line_item-quantity" class="quantity-controls__display">{item.quantity}</div>
-                                                <div data-package-id="{item.packageId}" data-next-quantity="increase" role="button" class="quantity-controls__button quantity-controls__button--increase">+</div>
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div class="cart-item__pricing">
-                                            <div class="checkout__line-item__final-price">{item.lineTotal}</div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </template>
-                                <div data-item-template-id="order-item-template" data-next-order-items="" class="cart-items__list"></div>
-                              </div>
-                            </div>
+                            {% campaign_include 'receipt-orders.html' %}
                             <div data-next-content="">
                               <div class="order-totals">
                                 <div class="order-totals__line">


### PR DESCRIPTION
## Summary

Zeros out the promoted-scope `lint:sdk` baseline and widens the CI gate to cover every promoted family across every page. Closes the last named open item from priorities.md checkpoint 8 ("zero out the promoted-scope lint baseline").

Before: `CI=1 node scripts/lint-sdk.mjs --scope=promoted --pages=all` → 39 violations after fresh rebuild (had appeared as 147 against a stale `_site/`).
After: `--scope=all --pages=all` → PASS.

## What changed

**Source mode (8 → 0):**
- Extract inline receipt order-item template + list into `receipt-orders.html` partial across `olympus`, `shop-three-step`, `olympus-mv-single-step`, `olympus-mv-two-step`. Each `receipt.html` replaces both desktop + mobile inline blocks with a single `campaign_include`. Receipts are byte-identical across families (except title frontmatter) so the partial body is the same in all four.

**Rendered mode (31 → 0):**
Add `data-next-catalog-component` wrapper to 7 partials that previously emitted SDK markup outside any catalog-component wrapper:

| Family | Partial | Catalog component |
|---|---|---|
| shop-three-step | cart-summary04 | order-summary |
| shop-three-step | payment-methods | payment-method-presentation |
| shop-three-step | express-checkout | express-checkout |
| shop-three-step | bump-check02 | order-bump-card |
| shop-three-step | receipt-skeleton | receipt-skeleton |
| olympus-mv-single-step | receipt-skeleton | receipt-skeleton |
| olympus-mv-two-step | receipt-skeleton | receipt-skeleton |

Component names mirror the canonical Olympus partials. No SDK runtime change — only a wrapper `<div>` is added.

**CI gate widened:**
- `lint:sdk:ci`: `--pages=checkout,select` → `--pages=all`
- New alias: `lint:sdk:promoted:all`

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint:sdk` (default olympus scope) PASS
- [x] `npm run lint:sdk:ci` (now all-scope all-pages) PASS
- [x] `CI=1 node scripts/lint-sdk.mjs --scope=promoted --pages=all` PASS
- [ ] Visual spot-check on the four receipt pages (olympus, shop-three-step, olympus-mv-single-step, olympus-mv-two-step) — markup is identical to pre-change, no SDK runtime impact, but worth a glance on the live preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
