### PR TITLE
[codex] Dispatch Campaigns OS catalog refreshes

### DIFF
--- a/.github/workflows/dispatch-campaigns-os-catalog-refresh.yml
+++ b/.github/workflows/dispatch-campaigns-os-catalog-refresh.yml
@@ -1,0 +1,32 @@
+name: Dispatch Campaigns OS Catalog Refresh
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/commerce-surface-catalog.json"
+      - "docs/fixtures/campaign-specs/**"
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Campaigns OS refresh workflow
+        env:
+          GH_TOKEN: ${{ secrets.CAMPAIGNS_OS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Set CAMPAIGNS_OS_DISPATCH_TOKEN with permission to dispatch workflows in NextCommerceCo/campaigns-os."
+            exit 1
+          fi
+
+          gh api \
+            --method POST \
+            repos/NextCommerceCo/campaigns-os/dispatches \
+            -f event_type=starter-template-catalog-updated \
+            -F "client_payload[source_repo]=${GITHUB_REPOSITORY}" \
+            -F "client_payload[source_ref]=${GITHUB_REF_NAME}" \
+            -F "client_payload[source_sha]=${GITHUB_SHA}" \
+            -F "client_payload[source_catalog]=docs/commerce-surface-catalog.json"

--- a/.github/workflows/dispatch-campaigns-os-catalog-refresh.yml
+++ b/.github/workflows/dispatch-campaigns-os-catalog-refresh.yml
@@ -7,7 +7,9 @@ on:
       - "docs/commerce-surface-catalog.json"
       - "docs/fixtures/campaign-specs/**"
 
-permissions: {}
+# The repository_dispatch call uses CAMPAIGNS_OS_DISPATCH_TOKEN, not GITHUB_TOKEN.
+permissions:
+  contents: read
 
 jobs:
   dispatch:


### PR DESCRIPTION
## Summary

- Add a template-repo workflow that dispatches a Campaigns OS catalog refresh after `docs/commerce-surface-catalog.json` or fixture specs change on `main`.
- Include source repo, source ref, source SHA, and catalog path in the repository dispatch payload.

## Why

Campaigns OS uses a vendored starter-template catalog snapshot. This makes template changes tell Campaigns OS when it should open a refresh PR instead of relying on release-time memory.

## Requirements

The template repo needs a `CAMPAIGNS_OS_DISPATCH_TOKEN` secret with permission to call repository dispatch on `NextCommerceCo/campaigns-os`.

## Validation

- `git diff --check`
- workflow YAML parse check via Ruby YAML loader

## Pairing

Companion receiver PR: https://github.com/NextCommerceCo/campaigns-os/pull/20