### PR TITLE
Use safe starter campaign defaults

### DIFF
--- a/_data/campaigns.json
+++ b/_data/campaigns.json
@@ -3,7 +3,7 @@
     "name": "Limos",
     "description": "Limos checkout funnel",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -13,14 +13,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "olympus": {
     "name": "Olympus",
     "description": "Olympus checkout funnel",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -30,14 +30,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "demeter": {
     "name": "Demeter",
     "description": "Demeter checkout funnel",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -47,14 +47,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "shop-single-step": {
     "name": "Shop Single Step",
     "description": "Shop single-step checkout funnel",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -64,14 +64,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "shop-three-step": {
     "name": "Shop Three Step",
     "description": "Shop three-step checkout funnel (information → shipping → billing)",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -81,14 +81,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "olympus-mv-single-step": {
     "name": "Olympus MV Single Step",
     "description": "Olympus multi-variant single-step checkout",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -98,14 +98,14 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "olympus-mv-two-step": {
     "name": "Olympus MV Two Step",
     "description": "Olympus multi-variant two-step checkout (select → checkout)",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",
@@ -115,13 +115,13 @@
     "store_shipping": "https://demo.29next.com/shipping/",
     "store_phone": "1 (888) 831-6810",
     "store_phone_tel": "tel:+18888316810",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   },
   "landing": {
     "name": "Landing",
     "description": "Landing page component library — niche example pages (supplement-sleep, skincare-serum, fitness-program) built from modular _includes sections",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Next Commerce",
     "store_url": "https://demo.29next.com/",
     "store_terms": "https://demo.29next.com/terms-conditions/",

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -146,7 +146,7 @@ Registers every campaign. The `campaign` object in Liquid templates comes from h
   "my-campaign": {
     "name": "My Campaign",
     "entry_url": "presell",
-    "sdk_version": "0.4.18",
+    "sdk_version": "0.4.19",
     "store_name": "Acme Store",
     "store_url": "https://acme.com",
     "store_phone": "1-800-555-0100",
@@ -156,8 +156,8 @@ Registers every campaign. The `campaign` object in Liquid templates comes from h
     "store_contact": "https://acme.com/contact",
     "store_returns": "https://acme.com/returns",
     "store_shipping": "https://acme.com/shipping",
-    "gtm_id": "GTM-XXXXXXX",
-    "fb_pixel_id": "123456789012345"
+    "gtm_id": "",
+    "fb_pixel_id": ""
   }
 }
 ```
@@ -166,7 +166,7 @@ The top-level key is the campaign slug. Add any additional key to a campaign ent
 
 **`entry_url`** — optional. The page slug `npm run dev` opens in the browser (e.g. `"presell"`). Omit to use the kit default.
 
-**`sdk_version`** — must be a **pinned semver string** from the starter reference (e.g. `"0.4.18"`), never `"latest"`. A wrong or stale version causes subtle Campaign Cart runtime behaviour with no obvious build error.
+**`sdk_version`** — must be a **pinned semver string** from the starter reference (e.g. `"0.4.19"`), never `"latest"`. A wrong or stale version causes subtle Campaign Cart runtime behaviour with no obvious build error.
 
 ### Build environment (`environment`)
 


### PR DESCRIPTION
## Summary
- update starter campaign references to Campaign Cart SDK 0.4.19
- default GTM and Meta Pixel fields to empty strings so non-dev previews do not load dummy analytics IDs
- update the AI context example to show disabled analytics by default

## Verification
- node -e "JSON.parse(require('fs').readFileSync('_data/campaigns.json','utf8')); console.log('campaigns.json ok')"
- npm run lint:agent-contracts

Linear: SELL-249