### PR TITLE
fix(bump-check01): default to single pricing row (per-unit), make line-total opt-in

### DIFF
--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -11,6 +11,8 @@
     title:              string, default "Get Extended Warranty".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
+    show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
     - data-next-toggle-card
@@ -29,6 +31,13 @@
 {% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="{{ sync_qty }}" data-next-package-id="{{ pkg_id }}">
@@ -46,16 +55,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             
 	            <div class="list-container cc-2xs">

--- a/src/limos/_includes/bump-check01.html
+++ b/src/limos/_includes/bump-check01.html
@@ -11,6 +11,8 @@
     title:              string, default "Get Extended Warranty".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
+    show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
     - data-next-toggle-card
@@ -29,6 +31,13 @@
 {% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="{{ sync_qty }}" data-next-package-id="{{ pkg_id }}">
@@ -46,16 +55,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             
 	            <div class="list-container cc-2xs">

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,7 +1,11 @@
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
@@ -19,16 +23,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,7 +1,11 @@
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
@@ -19,16 +23,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -14,7 +14,7 @@
     is_upsell:            bool, default true. data-next-is-upsell flag.
     features:             array of {text} strings, default warranty list. Bullet list shown under price.
     show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
-    show_line_total_price:bool, default true. Render Option B row (originalPrice + price).
+    show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
     - data-next-toggle-card
@@ -51,11 +51,13 @@
 {% assign feature_list = features | default: bump.features -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
-{% if show_line_total_price == nil %}{% assign show_line_total_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if package_sync %} data-next-package-sync="{{ package_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,7 +1,11 @@
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
@@ -19,16 +23,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             
             <div class="list-container cc-2xs">

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,7 +1,11 @@
+{% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
+     Pick ONE pricing row — rendering both confuses the customer.
+     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
+       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
@@ -19,16 +23,20 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
+              {% endif %}
+              {% if show_line_total_price %}
               <!-- Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
             </div>
             
             <div class="list-container cc-2xs">


### PR DESCRIPTION
## Summary
- `check01` prepurchase bump rendered both Option A (`unitPrice/ea`) **and** Option B (line total) by default across **all 7 starter templates**, producing a confusing doubled price display (e.g. `$3.00 $1.50/ea` stacked above `$9.00 $4.50`).
- Default to per-unit only (stable across tier changes per the partial's own comments). Line-total row is now opt-in via `show_line_total_price=true`.
- 4 of the 7 partials (`shop-*`, `olympus-mv-*`) had no Liquid params at all — hardcoded both rows. They now accept the same `show_per_unit_price` / `show_line_total_price` knobs as the olympus/limos/demeter partials so an agent can switch rows without forking the include.

## Why
Dropping the partial in with no overrides should produce a clean checkout. Forcing the user/agent to know to comment one row out was an unobvious tax.

## Scope (7 partials)
- [src/olympus/_includes/bump-check01.html](src/olympus/_includes/bump-check01.html) — flip `show_line_total_price` default `true` → `false`
- [src/limos/_includes/bump-check01.html](src/limos/_includes/bump-check01.html) — add params + conditionals (was hardcoded)
- [src/demeter/_includes/bump-check01.html](src/demeter/_includes/bump-check01.html) — add params + conditionals (was hardcoded)
- [src/shop-single-step/_includes/bump-check01.html](src/shop-single-step/_includes/bump-check01.html) — add params + conditionals
- [src/shop-three-step/_includes/bump-check01.html](src/shop-three-step/_includes/bump-check01.html) — add params + conditionals
- [src/olympus-mv-single-step/_includes/bump-check01.html](src/olympus-mv-single-step/_includes/bump-check01.html) — add params + conditionals
- [src/olympus-mv-two-step/_includes/bump-check01.html](src/olympus-mv-two-step/_includes/bump-check01.html) — add params + conditionals

## Out of scope (intentional)
The **bundle picker** (Step 1: Pick Your Bundle Deal) renders `$X/ea` AND `Total: $Y` for each tier card. That dual-display is **intentional and informative** for a tier comparison UI — the `/ea` is the comparison anchor, the total is the commit number. Not changing those partials (`bundle-selector.html`, `editorial-tier-selector.html`, `mv-configurable-selector.html`, `mv-slot-stage.html`).

A separate task is filed to document the bundle picker dual-display as intentional and to design a queryable component-contracts layer so agents can navigate presentation choices without inspecting partial source.

## Test plan
- [x] `npm run build` succeeds, 55 pages
- [x] `_site/olympus/checkout/index.html` and `_site/limos/checkout/index.html` render only the per-unit row for `Get Extended Warranty`
- [x] End-to-end render verification: forcing `order_bump_variant: "check01"` in `shop-single-step/checkout.html` and rebuilding produces exactly 1 price-row line (per-unit)
- [x] The `switch01` Olympus Checkout bump (separate partial) is unchanged
- [ ] Reviewer: confirm `npm run dev` preview matches expected single-row layout on `/olympus/checkout/`, `/limos/checkout/`, `/demeter/checkout/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)