### PR TITLE
feat(mv): quantity-synced order bump on MV checkouts (variant-safe)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,11 @@ scripts:
 | `data-next-coupon="input"` | Coupon input component |
 | `data-next-quantity="increase/decrease"` | Quantity controls |
 
+### Known limitation — `data-next-package-sync` on MV / configurable products
+A quantity-synced order bump (`data-next-package-sync`) matches cart lines by **packageId**. On MV / configurable selectors each variant (color/size) is a distinct package, and swapping a unit's variant rebuilds its cart line under the new variant's packageId (`originalPackageId: undefined`). So syncing to a single id under-counts the moment the customer mixes variants.
+- **Workaround (current, applied on `olympus-mv-single-step` + `olympus-mv-two-step` `bump-check01.html`):** list **every** variant ref_id of the synced product in `data-next-package-sync` (the SDK sums quantity across all listed ids). This is **fine for MV templates today** — it's variant-safe and verified working. Brittle by design: the ids are campaign-specific and must be updated when cloning to another product.
+- **Needed: a more robust SDK fix** — product-level sync (`data-next-product-sync="<productId>"`, matched on `item.productId` which every variant shares, summed via `filter`+`reduce`). Not in SDK 0.4.24. Once it ships + a version bump, the bump partials should emit `data-next-product-sync` by default for MV/configurable products and drop the per-variant id list.
+
 Inside `<template>` elements the SDK uses single-brace tokens (not Liquid):
 ```html
 <template id="cart-item-template">

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -8,7 +8,16 @@
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
+    <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — interim front-end workaround (no SDK change).
+         data-next-package-sync matches cart lines by packageId. On a configurable MV bundle each variant
+         (color/size) is its own package, and on variant swap the SDK rebuilds the line under the variant's
+         packageId (originalPackageId:undefined). Syncing to a single id under-counts the moment a unit is
+         swapped. Because the SDK sums quantity across EVERY id listed, list every variant ref_id of the
+         synced product so the bump tracks total qty regardless of which variants are chosen.
+         These ids are this demo campaign's product 400 ("T Shirt") variants (ref_ids 1-9 = checkout set,
+         66-74 = parallel "T Shirt Upsell" set a swap can resolve to). Replace with your product's ref_ids
+         when cloning. (Brittle by design — the durable fix is a product-level data-next-product-sync in the SDK.) -->
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1,2,3,4,5,6,7,8,9,66,67,68,69,70,71,72,73,74" data-next-package-id="77">
       <!-- Bump header — visual only, whole card is the toggle target -->
       <div class="bump__header-left">
         <div class="bump__header-content">

--- a/src/olympus-mv-single-step/checkout.html
+++ b/src/olympus-mv-single-step/checkout.html
@@ -361,6 +361,12 @@ swiper_thumbs:
                               <div class="text-xs-2"><strong>90 Day Money-Back Guarantee:</strong> Feel safe knowing you are protected with a 90 day guarantee. Simply send the item(s) back in the original packaging to receive a full refund or replacement, less S&amp;H.</div>
                               </div>
                             </div>
+                            <!-- Quantity-synced order bump (TEST): data-next-package-sync="1" mirrors the
+                                 main MV bundle (package id 1) quantity. Verifies whether the bump qty tracks
+                                 the configurable bundle tier (1x/2x/3x) selection on MV templates. -->
+                            <div class="form-section form-section--last">
+                              {% campaign_include 'bump-check01.html' packages=packages %}
+                            </div>
                             <div class="form-section form-section--last">
                               <div class="form-section__header">
                                 <h1 class="form-section__title">Payment</h1>

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -8,7 +8,16 @@
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
+    <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — interim front-end workaround (no SDK change).
+         data-next-package-sync matches cart lines by packageId. On a configurable MV bundle each variant
+         (color/size) is its own package, and on variant swap the SDK rebuilds the line under the variant's
+         packageId (originalPackageId:undefined). Syncing to a single id under-counts the moment a unit is
+         swapped. Because the SDK sums quantity across EVERY id listed, list every variant ref_id of the
+         synced product so the bump tracks total qty regardless of which variants are chosen.
+         These ids are this demo campaign's product 400 ("T Shirt") variants (ref_ids 1-9 = checkout set,
+         66-74 = parallel "T Shirt Upsell" set a swap can resolve to). Replace with your product's ref_ids
+         when cloning. (Brittle by design — the durable fix is a product-level data-next-product-sync in the SDK.) -->
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1,2,3,4,5,6,7,8,9,66,67,68,69,70,71,72,73,74" data-next-package-id="77">
       <!-- Bump header — visual only, whole card is the toggle target -->
       <div class="bump__header-left">
         <div class="bump__header-content">

--- a/src/olympus-mv-two-step/checkout.html
+++ b/src/olympus-mv-two-step/checkout.html
@@ -164,6 +164,10 @@ scripts:
                                   <div class="text-xs-2"><strong>90 Day Money-Back Guarantee:</strong> Feel safe knowing you are protected with a 90 day guarantee. Simply send the item(s) back in the original packaging to receive a full refund or replacement, less S&amp;H.</div>
                                 </div>
                               </div>
+                              <!-- Quantity-synced order bump — see bump-check01.html for the MV variant sync workaround. -->
+                              <div class="form-section form-section--last">
+                                {% campaign_include 'bump-check01.html' packages=packages %}
+                              </div>
                               <div class="form-section form-section--last">
                                 <div class="form-section__header">
                                   <h1 class="form-section__title">Payment</h1>


### PR DESCRIPTION
## What

Adds a quantity-synced order bump to both MV checkouts and documents an MV-specific limitation of \`data-next-package-sync\`.

- **olympus-mv-single-step** + **olympus-mv-two-step**: wire \`bump-check01.html\` into \`checkout.html\` (after the guarantee section, before Payment). Previously the bump partials existed but were never rendered on MV checkouts.
- Bump uses \`data-next-package-id="77"\` (Extended Warranty) and a variant-safe sync list.

## The bug this works around

\`data-next-package-sync\` matches cart lines by **packageId**. On MV / configurable selectors each variant (color/size) is a distinct package, and swapping a unit's variant rebuilds its cart line under the new variant's packageId (\`originalPackageId: undefined\`). Syncing to a single id (e.g. \`"1"\`) therefore **under-counts** the moment the customer mixes variants.

Repro: configurable bundle qty 7, all Black/Small → bump = 7 ✓; swap one unit to White/Small → bump drops to 6 ✗ (should stay 7).

## Workaround applied (front-end only, no SDK change)

The SDK sums quantity across **every** id listed in \`data-next-package-sync\`, so we list every variant ref_id of the synced product:

\`\`\`
data-next-package-sync="1,2,3,4,5,6,7,8,9,66,67,68,69,70,71,72,73,74"
\`\`\`

These are the shared demo campaign's product 400 ("T Shirt") variants (ref_ids 1-9 = checkout set, 66-74 = parallel "T Shirt Upsell" set a swap can resolve to). **Verified working** across variant swaps. Brittle by design — ids are campaign-specific and must be updated when cloning to another product.

## Follow-up (not in this PR)

The durable fix is an SDK-level **product-level sync**: \`data-next-product-sync="<productId>"\` matched on \`item.productId\` (shared by every variant), summed via \`filter\`+\`reduce\`. Not in SDK 0.4.24. Once it ships + a version bump, the bump partials should emit \`data-next-product-sync\` by default for MV/configurable products and drop the per-variant id list. Limitation + plan documented in \`CLAUDE.md\`.

## Notes

- Non-MV templates (olympus, limos, demeter, shop-*) are intentionally untouched — they're single-package products where single-id sync works correctly.
- Both MV templates share the same campaign/API key, so the same ref_id list is valid for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)