### PR TITLE
feat(demeter): declarative pricing_mode on pricing surfaces per brand contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,13 @@ A quantity-synced order bump matched by **packageId** (`data-next-package-sync`)
 - `data-next-package-sync` still works unchanged for single-package products. Both attributes may be set on the same card — items already counted by `data-next-package-sync` are excluded from the `data-next-product-sync` pass, so there is no double-counting.
 - **Prior workaround (pre-0.4.25, now retired):** hand-listing every variant ref_id in `data-next-package-sync`. Brittle — the list had to be updated whenever variants changed and broke silently if an id was missed.
 
+### Declarative pricing modes — Demeter (campaigns-os template-brand-contract.demeter.v0)
+Demeter pricing surfaces render price rows from a `pricing_mode` partial argument — campaigns must never hide `.price-wrapper` / `.prices-text-wrapper` / `.price-display` rows with CSS (Campaigns OS browser QA blocks upsells with zero visible price rows; a `display:none` on the only row caused the recovery-relief-stack-v1 dogfood blocker).
+- Modes: `full_price | discounted | compare_at | unit_total | unit_only`.
+- Surfaces + partial defaults (per contract): upsell offers (`upsell-bundle-stepper-offer.html`, `upsell-bundle-tier-pills-offer.html`, `upsell-bundle-tier-cards-offer.html`) default **full_price** — exactly one visible price row adjacent to the accept control; `bump-check01.html` defaults **full_price** (one `unitPrice`/ea row); `editorial-tier-selector.html` defaults **discounted** (current compare-unit-total render), with per-card override via `bundles[].pricing_mode`.
+- Pass the mode as an include arg (`pricing_mode='discounted'`) or via `upsell_offer.pricing_mode` / `order_bump.check01.pricing_mode` frontmatter; include arg wins. Visible-row counts on upsells: full_price/unit_only = 1, discounted/compare_at/unit_total = 2.
+- Demo pages opt into `discounted` explicitly to keep the showcase visuals; legacy `show_per_unit_price`/`show_line_total_price` (bump) and `price_display_variant` (tier selector) still work when passed explicitly without `pricing_mode`.
+
 Inside `<template>` elements the SDK uses single-brace tokens (not Liquid):
 ```html
 <template id="cart-item-template">

--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -13,9 +13,12 @@
     features:           array of bullet strings.
     pricing_mode:       enum [full_price, discounted, compare_at, unit_total, unit_only], default "full_price"
                         (template-brand-contract.demeter.v0 pricing_surfaces.bump). Include arg wins over
-                        order_bump.check01.pricing_mode. Controls which price rows render:
+                        order_bump.check01.pricing_mode, and over the legacy show_* bools below. Controls
+                        which price rows render:
                         full_price/unit_only = unitPrice/ea only (one visible price);
-                        discounted/compare_at = struck originalUnitPrice + unitPrice/ea;
+                        discounted/compare_at = struck originalUnitPrice + unitPrice/ea — IDENTICAL on this
+                        surface by design: data-next-toggle-display has no hasDiscount gating, so the struck
+                        original is always shown either way (compare_at semantics);
                         unit_total = unitPrice/ea + line total (scales with synced qty).
                         Pick the mode here — campaign CSS must never display:none price rows.
     show_per_unit_price:  bool, LEGACY. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
@@ -39,6 +42,9 @@
 {% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
+{% comment %} Precedence: pricing_mode (include arg, then bump.pricing_mode) wins; legacy show_per_unit_price /
+   show_line_total_price are honored ONLY when no pricing_mode is set anywhere — if both are passed, the
+   legacy bools are ignored. {% endcomment -%}
 {% assign bump_pricing_mode = pricing_mode | default: bump.pricing_mode -%}
 {% assign legacy_price_rows = false -%}
 {% if bump_pricing_mode == nil -%}
@@ -90,12 +96,9 @@
               {% else %}
               <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
               {% case bump_pricing_mode %}
-              {% when 'discounted' %}
-              <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
-                <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
-              </div>
-              {% when 'compare_at' %}
+              {% when 'discounted', 'compare_at' %}
+              <!-- One shared branch by design: toggle-display has no hasDiscount gating, so the struck
+                   originalUnitPrice is always shown — both modes resolve to compare_at semantics here. -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>

--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -11,8 +11,16 @@
     title:              string, default "Get Extended Warranty".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
-    show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
-    show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
+    pricing_mode:       enum [full_price, discounted, compare_at, unit_total, unit_only], default "full_price"
+                        (template-brand-contract.demeter.v0 pricing_surfaces.bump). Include arg wins over
+                        order_bump.check01.pricing_mode. Controls which price rows render:
+                        full_price/unit_only = unitPrice/ea only (one visible price);
+                        discounted/compare_at = struck originalUnitPrice + unitPrice/ea;
+                        unit_total = unitPrice/ea + line total (scales with synced qty).
+                        Pick the mode here — campaign CSS must never display:none price rows.
+    show_per_unit_price:  bool, LEGACY. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_line_total_price:bool, LEGACY. Render Option B row (originalPrice + price). Only honored when
+                        pricing_mode is not set and at least one legacy bool is passed explicitly.
   next_sdk_owns:
     - data-next-package-toggle
     - data-next-toggle-card
@@ -31,13 +39,22 @@
 {% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
+{% assign bump_pricing_mode = pricing_mode | default: bump.pricing_mode -%}
+{% assign legacy_price_rows = false -%}
+{% if bump_pricing_mode == nil -%}
+  {% if show_per_unit_price != nil or show_line_total_price != nil -%}
+    {% assign legacy_price_rows = true -%}
+  {% else -%}
+    {% assign bump_pricing_mode = 'full_price' -%}
+  {% endif -%}
+{% endif -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
-     Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
-     Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+     Pricing rows are pricing_mode-driven (default full_price = one visible unitPrice/ea row).
+     Legacy show_per_unit_price / show_line_total_price still work when passed explicitly without pricing_mode:
+     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="{{ sync_qty }}" data-next-package-id="{{ pkg_id }}">
@@ -55,19 +72,45 @@
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
+              {% if legacy_price_rows %}
               {% if show_per_unit_price %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              <!-- Legacy Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if show_line_total_price %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              <!-- Legacy Option B: line total pricing — scales with synced qty -->
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>
               </div>
+              {% endif %}
+              {% else %}
+              <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+              {% case bump_pricing_mode %}
+              {% when 'discounted' %}
+              <div class="bump__price-row">
+                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
+              </div>
+              {% when 'compare_at' %}
+              <div class="bump__price-row">
+                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
+              </div>
+              {% when 'unit_total' %}
+              <div class="bump__price-row">
+                <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
+                <div data-next-toggle-display="price" class="bump__price-total">--</div>
+              </div>
+              {% else %}
+              <!-- full_price / unit_only (default full_price): one visible price row -->
+              <div class="bump__price-row">
+                <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
+              </div>
+              {% endcase %}
               {% endif %}
             </div>
             

--- a/src/demeter/_includes/editorial-tier-selector.html
+++ b/src/demeter/_includes/editorial-tier-selector.html
@@ -106,7 +106,10 @@
           </div>
               {% assign card_price_variant = b.price_display_variant | default: selector_price_variant -%}
               {% assign card_pricing_mode = b.pricing_mode | default: selector_pricing_mode -%}
-              {%- comment %} pricing_mode picks the rows — never hide price rows with campaign CSS {% endcomment %}
+              {%- comment %} pricing_mode picks the rows — never hide price rows with campaign CSS.
+                 Unit-row precedence: hidden for full_price/compare_at modes, AND independently by the
+                 legacy price_display_variant=total-only axis — a card with pricing_mode=unit_total but
+                 variant total-only still suppresses the unit row (legacy wins on its own axis). {% endcomment %}
               {% assign show_unit_row = true -%}
               {% if card_pricing_mode == 'full_price' or card_pricing_mode == 'compare_at' or card_price_variant == 'total-only' %}{% assign show_unit_row = false %}{% endif -%}
               <div class="os-card__secondary-slot">
@@ -141,6 +144,8 @@
     </div>
     {% endfor -%}
     {% else -%}
+    {%- comment %} Canonical 1x/2x/3x fallback cards: only the include-level selector_pricing_mode applies —
+       per-card pricing_mode overrides require passing an explicit `bundles` array. {% endcomment -%}
     {%- assign _pkg = packages.main_package | default: 1 -%}
     {%- assign _standard_ship = shipping_methods.standard -%}
     {%- assign _free_ship = shipping_methods.free -%}

--- a/src/demeter/_includes/editorial-tier-selector.html
+++ b/src/demeter/_includes/editorial-tier-selector.html
@@ -14,7 +14,15 @@
 	                        Each card: { id, quantity, shipping_method, shipping_id, items_json, selected, title_prefix,
 	                          package_id, subtitle_text, shipping_label, total_tone_class,
 	                          badge_text, badge_class, price_display_variant }
-	    price_display_variant: enum [compare-unit-total, total-only], default "compare-unit-total".
+	    price_display_variant: enum [compare-unit-total, total-only], default "compare-unit-total". LEGACY axis;
+	                        total-only still suppresses the per-unit row. Prefer pricing_mode for new campaigns.
+	    pricing_mode:       enum [full_price, discounted, compare_at, unit_total, unit_only], default "discounted"
+	                        (template-brand-contract.demeter.v0 pricing_surfaces.checkout_bundle). Per-card override
+	                        via bundles[].pricing_mode. Controls which price rows render:
+	                        discounted = hasDiscount-gated struck compares + unitPrice/ea + total (current default);
+	                        compare_at = always-shown struck compare total + total; full_price = total only;
+	                        unit_total = unitPrice/ea + total, no compares; unit_only = unitPrice/ea only.
+	                        Pick the mode here — campaign CSS must never display:none price rows.
   next_sdk_owns:
     - data-next-bundle-selector
     - data-next-selector-id
@@ -48,6 +56,7 @@
 {% assign sel_id = selector_id | default: 'main' -%}
 {% assign sel_mode = selection_mode | default: 'swap' -%}
 {% assign selector_price_variant = price_display_variant | default: 'compare-unit-total' -%}
+{% assign selector_pricing_mode = pricing_mode | default: 'discounted' -%}
 {% if include_shipping == nil %}{% assign include_shipping = true %}{% endif -%}
 {% if await == nil %}{% assign await = true %}{% endif -%}
 <div data-next-catalog-component="editorial-tier-selector" data-next-bundle-selector data-next-selector-id="{{ sel_id }}" data-next-selection-mode="{{ sel_mode }}"{% if include_shipping %} data-next-include-shipping="true"{% endif %} class="os-option"{% if await %} data-next-await=""{% endif %}>
@@ -96,19 +105,26 @@
             </div>
           </div>
               {% assign card_price_variant = b.price_display_variant | default: selector_price_variant -%}
+              {% assign card_pricing_mode = b.pricing_mode | default: selector_pricing_mode -%}
+              {%- comment %} pricing_mode picks the rows — never hide price rows with campaign CSS {% endcomment %}
+              {% assign show_unit_row = true -%}
+              {% if card_pricing_mode == 'full_price' or card_pricing_mode == 'compare_at' or card_price_variant == 'total-only' %}{% assign show_unit_row = false %}{% endif -%}
               <div class="os-card__secondary-slot">
 	            <div class="os-card__pricing">
-	              {% unless card_price_variant == 'total-only' %}
+	              {% if show_unit_row %}
 	              <div class="os-card__price-container">
-	                <div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>
+	                {% if card_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>{% endif %}
 	                <div class="os-card__price os--current"><span data-next-bundle-display="unitPrice">-</span>/ea</div>
 	              </div>
-	              {% endunless %}
+	              {% endif %}
+	              {% unless card_pricing_mode == 'unit_only' %}
 	              <div class="os-card__total-container">
 	                <div class="os-card__total-label">Total:</div>
-                <div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% if card_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% elsif card_pricing_mode == 'compare_at' %}<div class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>{% endif %}
                 <div class="os-card__total-current{% if b.total_tone_class %} {{ b.total_tone_class }}{% endif %}"><span data-next-bundle-display="price">-</span></div>
               </div>
+              {% endunless %}
             </div>
           </div>
         </div>
@@ -154,15 +170,20 @@
           </div>
           <div class="os-card__secondary-slot">
             <div class="os-card__pricing">
+              {% unless selector_pricing_mode == 'full_price' or selector_pricing_mode == 'compare_at' %}
               <div class="os-card__price-container">
-                <div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>{% endif %}
                 <div class="os-card__price os--current"><span data-next-bundle-display="unitPrice">-</span>/ea</div>
               </div>
+              {% endunless %}
+              {% unless selector_pricing_mode == 'unit_only' %}
               <div class="os-card__total-container">
                 <div class="os-card__total-label">Total:</div>
-                <div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% elsif selector_pricing_mode == 'compare_at' %}<div class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>{% endif %}
                 <div class="os-card__total-current"><span data-next-bundle-display="price">-</span></div>
               </div>
+              {% endunless %}
             </div>
           </div>
         </div>
@@ -201,15 +222,20 @@
           </div>
           <div class="os-card__secondary-slot">
             <div class="os-card__pricing">
+              {% unless selector_pricing_mode == 'full_price' or selector_pricing_mode == 'compare_at' %}
               <div class="os-card__price-container">
-                <div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>{% endif %}
                 <div class="os-card__price os--current"><span data-next-bundle-display="unitPrice">-</span>/ea</div>
               </div>
+              {% endunless %}
+              {% unless selector_pricing_mode == 'unit_only' %}
               <div class="os-card__total-container">
                 <div class="os-card__total-label">Total:</div>
-                <div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% elsif selector_pricing_mode == 'compare_at' %}<div class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>{% endif %}
                 <div class="os-card__total-current"><span data-next-bundle-display="price">-</span></div>
               </div>
+              {% endunless %}
             </div>
           </div>
         </div>
@@ -245,15 +271,20 @@
           </div>
           <div class="os-card__secondary-slot">
             <div class="os-card__pricing">
+              {% unless selector_pricing_mode == 'full_price' or selector_pricing_mode == 'compare_at' %}
               <div class="os-card__price-container">
-                <div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__price os--compare os-style"><span data-next-bundle-display="originalUnitPrice">-</span></div>{% endif %}
                 <div class="os-card__price os--current"><span data-next-bundle-display="unitPrice">-</span>/ea</div>
               </div>
+              {% endunless %}
+              {% unless selector_pricing_mode == 'unit_only' %}
               <div class="os-card__total-container">
                 <div class="os-card__total-label">Total:</div>
-                <div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% if selector_pricing_mode == 'discounted' %}<div data-next-bundle-display="hasDiscount" class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>
+                {% elsif selector_pricing_mode == 'compare_at' %}<div class="os-card__total-compare"><span data-next-bundle-display="originalPrice">-</span></div>{% endif %}
                 <div class="os-card__total-current os-dark"><span data-next-bundle-display="price">-</span></div>
               </div>
+              {% endunless %}
             </div>
           </div>
         </div>

--- a/src/demeter/_includes/upsell-bundle-stepper-offer.html
+++ b/src/demeter/_includes/upsell-bundle-stepper-offer.html
@@ -4,7 +4,12 @@
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
   next_sdk_surface: upsell offer
   next_params:
-    upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
+    upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text, pricing_mode.
+    pricing_mode: enum [full_price, discounted, compare_at, unit_total, unit_only], default "full_price".
+                  Include arg wins over upsell_offer.pricing_mode. Controls which .price-wrapper rows render
+                  (template-brand-contract.demeter.v0 pricing_surfaces.upsell): full_price/unit_only render
+                  exactly 1 visible price row adjacent to the accept control; discounted/compare_at/unit_total render 2.
+                  Pick the mode here — campaign CSS must never display:none a .price-wrapper/.prices-text-wrapper row.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
 -->
 {% assign offer = upsell_offer -%}
@@ -20,6 +25,8 @@
 {% assign bundle_price_path = 'bundle.' | append: selector_id | append: '.price' -%}
 {% assign bundle_original_price_path = 'bundle.' | append: selector_id | append: '.originalPrice' -%}
 {% assign bundle_discount_path = 'bundle.' | append: selector_id | append: '.discountPercentage' -%}
+{% assign bundle_unit_price_path = 'bundle.' | append: selector_id | append: '.unitPrice' -%}
+{% assign pricing_mode = pricing_mode | default: offer.pricing_mode | default: 'full_price' -%}
 <div data-next-catalog-component="upsell-bundle-stepper-offer">
       <section class="section upsell-box">
         <div class="container">
@@ -105,6 +112,9 @@
                         </div>
                       </div>
 
+                      <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                      {% case pricing_mode %}
+                      {% when 'discounted' %}
                       <div class="prices-text-wrapper">
                         <div class="price-wrapper">
                           <div class="text-sm tw-600">Retail Price</div>
@@ -131,6 +141,70 @@
                           <div class="text-xs font-bold color-primary">+ FREE SHIPPING</div>
                         </div>
                       </div>
+                      {% when 'compare_at' %}
+                      <div class="prices-text-wrapper">
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Regular Price</div>
+                          <div
+                            class="upsell-offer__price diagonal-strike color-muted"
+                            data-next-display="{{ bundle_original_price_path }}"
+                            data-next-format="currency"
+                          >$49.99</div>
+                        </div>
+                        <div class="upsell-offer__divider"></div>
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Today's Price</div>
+                          <div
+                            class="upsell-offer__price"
+                            data-next-display="{{ bundle_price_path }}"
+                            data-next-format="currency"
+                          >$24.95</div>
+                        </div>
+                      </div>
+                      {% when 'unit_total' %}
+                      <div class="prices-text-wrapper">
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Price Per Unit</div>
+                          <div
+                            class="upsell-offer__price"
+                            data-next-display="{{ bundle_unit_price_path }}"
+                            data-next-format="currency"
+                          >$24.95</div>
+                        </div>
+                        <div class="upsell-offer__divider"></div>
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Total</div>
+                          <div
+                            class="upsell-offer__price"
+                            data-next-display="{{ bundle_price_path }}"
+                            data-next-format="currency"
+                          >$24.95</div>
+                        </div>
+                      </div>
+                      {% when 'unit_only' %}
+                      <div class="prices-text-wrapper">
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Price Per Unit</div>
+                          <div
+                            class="upsell-offer__price"
+                            data-next-display="{{ bundle_unit_price_path }}"
+                            data-next-format="currency"
+                          >$24.95</div>
+                        </div>
+                      </div>
+                      {% else %}
+                      <!-- full_price (default): exactly one visible price row adjacent to the accept control -->
+                      <div class="prices-text-wrapper">
+                        <div class="price-wrapper">
+                          <div class="text-sm tw-600">Price</div>
+                          <div
+                            class="upsell-offer__price"
+                            data-next-display="{{ bundle_price_path }}"
+                            data-next-format="currency"
+                          >$24.95</div>
+                        </div>
+                      </div>
+                      {% endcase %}
 
                       <a
                         data-next-upsell-action="add"

--- a/src/demeter/_includes/upsell-bundle-stepper-offer.html
+++ b/src/demeter/_includes/upsell-bundle-stepper-offer.html
@@ -112,7 +112,9 @@
                         </div>
                       </div>
 
-                      <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                      <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead.
+                           $ amounts are SSR placeholders: the offer wrapper is [data-next-await]-skeletoned until the
+                           SDK hydrates bundle.{{ selector_id }}.* — configure the bundle selector so those paths resolve. -->
                       {% case pricing_mode %}
                       {% when 'discounted' %}
                       <div class="prices-text-wrapper">

--- a/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
@@ -4,8 +4,13 @@
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
   next_sdk_surface: upsell offer
   next_params:
-    upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
+    upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text, pricing_mode.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
+    pricing_mode: enum [full_price, discounted, compare_at, unit_total, unit_only], default "full_price".
+                  Include arg wins over upsell_offer.pricing_mode. Controls which .price-wrapper rows render
+                  (template-brand-contract.demeter.v0 pricing_surfaces.upsell): full_price/unit_only render
+                  exactly 1 visible price row adjacent to the accept control; discounted/compare_at/unit_total render 2.
+                  Pick the mode here — campaign CSS must never display:none a .price-wrapper/.prices-text-wrapper row.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
 -->
 {% assign offer = upsell_offer -%}
@@ -19,6 +24,8 @@
 {% assign bundle_price_path = 'bundle.' | append: selector_id | append: '.price' -%}
 {% assign bundle_original_price_path = 'bundle.' | append: selector_id | append: '.originalPrice' -%}
 {% assign bundle_discount_path = 'bundle.' | append: selector_id | append: '.discountPercentage' -%}
+{% assign bundle_unit_price_path = 'bundle.' | append: selector_id | append: '.unitPrice' -%}
+{% assign pricing_mode = pricing_mode | default: offer.pricing_mode | default: 'full_price' -%}
 <div data-next-catalog-component="upsell-bundle-tier-cards-offer">
       <section class="section upsell-box">
         <div class="container">
@@ -107,6 +114,9 @@
                         {% endfor %}
                       </div>
                     </div>
+                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                    {% case pricing_mode %}
+                    {% when 'discounted' %}
                     <div class="prices-text-wrapper">
                       <div class="price-wrapper">
                         <div class="text-sm tw-600">Retail Price</div>
@@ -123,6 +133,46 @@
                         <div class="text-xs font-bold color-primary">+ FREE SHIPPING</div>
                       </div>
                     </div>
+                    {% when 'compare_at' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Regular Price</div>
+                        <div class="upsell-offer__price diagonal-strike color-muted" data-next-display="{{ bundle_original_price_path }}" data-next-format="currency">$49.99</div>
+                      </div>
+                      <div class="upsell-offer__divider"></div>
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Selected offer total</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% when 'unit_total' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Price Per Unit</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_unit_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                      <div class="upsell-offer__divider"></div>
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Selected offer total</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% when 'unit_only' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Price Per Unit</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_unit_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% else %}
+                    <!-- full_price (default): exactly one visible price row adjacent to the accept control -->
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Selected offer total</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% endcase %}
                     <a data-next-upsell-action="add" href="#" class="button" pb-animate="pulse-upsell">
                       <div data-button="content" class="button_content"><div>{{ offer.accept_text | default: 'Yes, Add to My Order' }}</div></div>
                     </a>

--- a/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
@@ -114,7 +114,9 @@
                         {% endfor %}
                       </div>
                     </div>
-                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead.
+                         $ amounts are SSR placeholders: the offer wrapper is [data-next-await]-skeletoned until the
+                         SDK hydrates bundle.{{ selector_id }}.* — configure the bundle selector so those paths resolve. -->
                     {% case pricing_mode %}
                     {% when 'discounted' %}
                     <div class="prices-text-wrapper">

--- a/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
@@ -127,7 +127,9 @@
                       display often yields unformatted numbers — keep data-next-format="currency" on
                       originalPrice / price (see file header / safe-display-paths.md).
                     -->
-                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead.
+                         $ amounts are SSR placeholders: the offer wrapper is [data-next-await]-skeletoned until the
+                         SDK hydrates bundle.{{ selector_id }}.* — configure the bundle selector so those paths resolve. -->
                     {% case pricing_mode %}
                     {% when 'discounted' %}
                     <div class="prices-text-wrapper">

--- a/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
@@ -4,8 +4,13 @@
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
   next_sdk_surface: upsell offer
   next_params:
-    upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
+    upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text, pricing_mode.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
+    pricing_mode: enum [full_price, discounted, compare_at, unit_total, unit_only], default "full_price".
+                  Include arg wins over upsell_offer.pricing_mode. Controls which .price-wrapper rows render
+                  (template-brand-contract.demeter.v0 pricing_surfaces.upsell): full_price/unit_only render
+                  exactly 1 visible price row adjacent to the accept control; discounted/compare_at/unit_total render 2.
+                  Pick the mode here — campaign CSS must never display:none a .price-wrapper/.prices-text-wrapper row.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
 -->
 {% assign offer = upsell_offer -%}
@@ -19,6 +24,8 @@
 {% assign bundle_price_path = 'bundle.' | append: selector_id | append: '.price' -%}
 {% assign bundle_original_price_path = 'bundle.' | append: selector_id | append: '.originalPrice' -%}
 {% assign bundle_discount_path = 'bundle.' | append: selector_id | append: '.discountPercentage' -%}
+{% assign bundle_unit_price_path = 'bundle.' | append: selector_id | append: '.unitPrice' -%}
+{% assign pricing_mode = pricing_mode | default: offer.pricing_mode | default: 'full_price' -%}
 <div data-next-catalog-component="upsell-bundle-tier-pills-offer">
       <section class="section upsell-box">
         <div class="container">
@@ -120,6 +127,9 @@
                       display often yields unformatted numbers — keep data-next-format="currency" on
                       originalPrice / price (see file header / safe-display-paths.md).
                     -->
+                    <!-- pricing_mode-driven price rows — never hide rows with campaign CSS; pick the mode instead -->
+                    {% case pricing_mode %}
+                    {% when 'discounted' %}
                     <div class="prices-text-wrapper">
                       <div class="price-wrapper">
                         <div class="text-sm tw-600">Retail Price</div>
@@ -137,6 +147,46 @@
                         <div class="text-xs font-bold color-primary">+ FREE SHIPPING</div>
                       </div>
                     </div>
+                    {% when 'compare_at' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Regular Price</div>
+                        <div class="upsell-offer__price diagonal-strike color-muted" data-next-display="{{ bundle_original_price_path }}" data-next-format="currency">$49.99</div>
+                      </div>
+                      <div class="upsell-offer__divider"></div>
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Today's Price</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% when 'unit_total' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Price Per Unit</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_unit_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                      <div class="upsell-offer__divider"></div>
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Total</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% when 'unit_only' %}
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Price Per Unit</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_unit_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% else %}
+                    <!-- full_price (default): exactly one visible price row adjacent to the accept control -->
+                    <div class="prices-text-wrapper">
+                      <div class="price-wrapper">
+                        <div class="text-sm tw-600">Price</div>
+                        <div class="upsell-offer__price" data-next-display="{{ bundle_price_path }}" data-next-format="currency">$24.95</div>
+                      </div>
+                    </div>
+                    {% endcase %}
                     <!--
                       UpsellEnhancer does not use data-next-upsell-action-for (AcceptUpsellEnhancer).
                       Bundle for add comes from the first [data-next-bundle-selector] in this offer (upsell-bundle).

--- a/src/demeter/checkout.html
+++ b/src/demeter/checkout.html
@@ -241,6 +241,9 @@ scripts:
                                 </div>
 
                                 {% assign bump_variant = order_bump_variant | default: 'check01+switch01' %}
+                                <!-- DEMO-ONLY override: pricing_mode='discounted' keeps the showcase's struck-price look.
+                                     The contract default for bumps is full_price (single unitPrice/ea row) — when cloning
+                                     this page for a real campaign, drop the arg unless the bump has a genuine discount. -->
                                 {% case bump_variant %}
                                 {% when 'check01' %}
                                 {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}

--- a/src/demeter/checkout.html
+++ b/src/demeter/checkout.html
@@ -243,12 +243,12 @@ scripts:
                                 {% assign bump_variant = order_bump_variant | default: 'check01+switch01' %}
                                 {% case bump_variant %}
                                 {% when 'check01' %}
-                                {% campaign_include 'bump-check01.html' packages=packages %}
+                                {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
                                 {% when 'switch01' %}
                                 {% campaign_include 'bump-switch01.html' packages=packages %}
                                 {% when 'none', 'off', 'false' %}
                                 {% else %}
-                                {% campaign_include 'bump-check01.html' packages=packages %}
+                                {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
                                 {% campaign_include 'bump-switch01.html' packages=packages %}
                                 {% endcase %}
                                 <div class="form-section form-section--last">

--- a/src/demeter/upsell-bundle-stepper.html
+++ b/src/demeter/upsell-bundle-stepper.html
@@ -17,6 +17,7 @@ upsell_offer:
   default_quantity: 1
   min_quantity: 1
   max_quantity: 5
+  pricing_mode: discounted
   accept_text: "Yes, Add to My Order"
   decline_text: "No thank you, I don't want this one-time offer"
 swiper_slides:

--- a/src/demeter/upsell-bundle-tier-cards.html
+++ b/src/demeter/upsell-bundle-tier-cards.html
@@ -14,6 +14,7 @@ upsell_offer:
   display_selector_id: "upsell-bundle-1x"
   display_bundle_id: "upsell-bundle-1x-card"
   header_discount_selector_id: "upsell-bundle-3x"
+  pricing_mode: discounted
   accept_text: "Yes, Add to My Order"
   decline_text: "No thank you, I don't want this one-time offer"
 upsell_bundle_tiers:

--- a/src/demeter/upsell-bundle-tier-pills.html
+++ b/src/demeter/upsell-bundle-tier-pills.html
@@ -13,6 +13,7 @@ upsell_offer:
   selector_id: "upsell-bundle"
   display_selector_id: "upsell-bundle-1x"
   display_bundle_id: "upsell-bundle-1x-card"
+  pricing_mode: discounted
   accept_text: "Yes, Add to My Order"
   decline_text: "No thank you, I don't want this one-time offer"
 upsell_bundle_tiers:


### PR DESCRIPTION
## What

Adds declarative pricing-mode support to the Demeter family per the `pricing_surfaces` section of `contracts/template-brand-contract.demeter.v0.json` shipped in [campaigns-os#89](https://github.com/NextCommerceCo/campaigns-os/pull/89). Pricing surfaces now render the right price rows from a `pricing_mode` partial argument — `full_price | discounted | compare_at | unit_total | unit_only` — instead of campaigns hiding rows with CSS.

Background: in the recovery-relief-stack-v1 dogfood, a campaign CSS rule (`.rr-full-price .price-wrapper:first-child { display:none!important }`) hid the only visible price on a full-price upsell. Campaigns OS browser QA now blocks upsells with zero visible price rows; this makes the mode a template argument so that CSS hack is never needed.

## Surfaces + defaults (per contract)

| Surface | Partial | Default mode |
|---|---|---|
| Upsell offer | `upsell-bundle-stepper-offer.html`, `upsell-bundle-tier-pills-offer.html`, `upsell-bundle-tier-cards-offer.html` | `full_price` — exactly **one** visible `.price-wrapper` adjacent to the accept control |
| Prepurchase bump | `bump-check01.html` | `full_price` — single `unitPrice`/ea row |
| Checkout bundle | `editorial-tier-selector.html` | `discounted` — current compare-unit-total render; per-card override via `bundles[].pricing_mode` |

Mode is passed as an include arg (`pricing_mode='discounted'`) or via `upsell_offer.pricing_mode` / `order_bump.check01.pricing_mode` frontmatter; the include arg wins. Visible upsell price rows by mode match the contract: full_price/unit_only = 1, discounted/compare_at/unit_total = 2.

## Back-compat

- Bump: legacy `show_per_unit_price` / `show_line_total_price` still honored when passed explicitly without `pricing_mode`.
- Tier selector: legacy `price_display_variant: total-only` still suppresses the per-unit row.
- Demo pages opt into `discounted` explicitly — built demeter output is content-identical to the previous build (comment/whitespace-only diff, verified with `diff -wB` against a pre-change build of all 7 demeter pages).

## Verification

Built all campaigns with modes flipped and counted rendered rows:
- full_price upsell (stepper): **1** `.price-wrapper` (QA full_price requirement ✅)
- unit_total (pills): 2 rows; compare_at (pills): 2 rows, one struck; unit_only (cards): 1 row
- full_price bump: 1 `bump__price-row`, no struck `originalUnitPrice`
- full_price checkout bundle: totals only, zero compare elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)