### PR TITLE
fix: normalize exit-intent coupon default to EXIT10 across families

### DIFF
--- a/src/demeter/_includes/exit-intent-popup.html
+++ b/src/demeter/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: EXIT5)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT5{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 

--- a/src/limos/_includes/exit-intent-popup.html
+++ b/src/limos/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: SAVE10)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}SAVE10{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 

--- a/src/limos/assets/js/checkout-limos.js
+++ b/src/limos/assets/js/checkout-limos.js
@@ -8,6 +8,6 @@ window.addEventListener('next:initialized', function() {
 
   // Image-only alternative — swap in your own image URL and uncomment to use instead
   // initExitIntentImage('https://placehold.co/600x400', async () => {
-  //   await next.applyCoupon('SAVE10');
+  //   await next.applyCoupon('EXIT10');
   // });
 });

--- a/src/olympus-mv-single-step/_includes/exit-intent-popup.html
+++ b/src/olympus-mv-single-step/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: SAVE10)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}SAVE10{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 

--- a/src/olympus-mv-single-step/assets/js/checkout-olympus-mv-full.js
+++ b/src/olympus-mv-single-step/assets/js/checkout-olympus-mv-full.js
@@ -304,7 +304,7 @@ window.addEventListener('next:initialized', function () {
   setupBundleSlotVariantDropdowns(); // comment out to use barebones native <select> UI instead
 
   // Image-only exit intent — replace with your own image URL
-  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT5)
+  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT10)
   initExitIntentImage('https://placehold.co/600x400', async () => {
     await next.applyCoupon('EXIT10');
   });

--- a/src/olympus-mv-two-step/_includes/exit-intent-popup.html
+++ b/src/olympus-mv-two-step/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: SAVE10)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}SAVE10{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 

--- a/src/olympus-mv-two-step/assets/js/checkout-olympus-mv-full.js
+++ b/src/olympus-mv-two-step/assets/js/checkout-olympus-mv-full.js
@@ -305,7 +305,7 @@ window.addEventListener('next:initialized', function () {
   setupBundleSlotVariantDropdowns(); // comment out to use barebones native <select> UI instead
 
   // Image-only exit intent — replace with your own image URL
-  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT5)
+  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT10)
   initExitIntentImage('https://placehold.co/600x400', async () => {
     await next.applyCoupon('EXIT10');
   });

--- a/src/olympus/_includes/exit-intent-popup.html
+++ b/src/olympus/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: EXIT5)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT5{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 

--- a/src/olympus/assets/js/checkout-olympus.js
+++ b/src/olympus/assets/js/checkout-olympus.js
@@ -2,7 +2,7 @@ window.addEventListener('next:initialized', function() {
   initFomo();
 
   // Image-only exit intent — replace with your own image URL
-  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT5)
+  // Coupon must exist on the campaign (Campaigns app → discount code offer, e.g. EXIT10)
   initExitIntentImage('https://placehold.co/600x400', async () => {
     await next.applyCoupon('EXIT10');
   });

--- a/src/shop-single-step/_includes/exit-intent-popup.html
+++ b/src/shop-single-step/_includes/exit-intent-popup.html
@@ -2,7 +2,7 @@
      Include on checkout pages that use initExitIntentTemplate().
      Requires css/exit-intent-popup.css in page frontmatter styles.
      Args:
-       coupon_code   — coupon to apply on CTA click   (default: SAVE10)
+       coupon_code   — coupon to apply on CTA click   (default: EXIT10)
        popup_image   — left-column image URL          (required)
        headline      — large headline text            (default: Wait!)
        subheadline   — line below headline            (default: Are you sure you want to leave?)
@@ -41,7 +41,7 @@
           <button type="button"
                   class="exit-intent-popup__cta"
                   data-exit-intent-action="apply-coupon"
-                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}SAVE10{% endif %}">
+                  data-coupon-code="{% if coupon_code %}{{ coupon_code }}{% else %}EXIT10{% endif %}">
             {% if cta_label %}{{ cta_label }}{% else %}Apply My Discount Coupon{% endif %}
           </button>
 


### PR DESCRIPTION
Addresses **D1.5** from the cross-family include-drift inventory (#64).

## Problem
The `exit-intent-popup.html` partial's fallback coupon default had drifted across families and **never matched the coupon the demo campaigns actually accept**:
- `EXIT5` in olympus + demeter
- `SAVE10` in the other families
- but every family's `applyCoupon(...)` call (and `limos/checkout.html`'s include arg) already uses **`EXIT10`** — the live code

The drifted values only ever surfaced as the partial's `{% else %}…{% endif %}` fallback, so the inconsistency was latent but wrong.

## Change
Standardize on **`EXIT10`** everywhere:
- 6 `exit-intent-popup.html` partials — fallback default + doc-comment
- stale `e.g. EXIT5` comments in 3 `checkout-*.js` files
- a commented `applyCoupon('SAVE10')` example in `checkout-limos.js`

No behavioral change to the live exit-intent flow (which already applied `EXIT10`); this aligns the partial default and developer-facing comments with reality.

## Scope note
Part of #64's D1 tier. The other D1 items are intentionally **not** included here — on inspection several (receipt-skeleton, cart-summary03) turned out to be annotation-parity (D2) work or intentional per-family variants, not mechanical fixes. `cta_params` (D1.3) will follow as a separate focused PR. `initialDelay` (D1.4) is deferred for separate review.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)