### PR TITLE
feat(landing): add cta_params passthrough to section-library CTAs

### DIFF
--- a/src/landing/_includes/bottomcta-1.html
+++ b/src/landing/_includes/bottomcta-1.html
@@ -44,7 +44,7 @@
         </div>
 
         <div class="w-full max-w-none md:max-w-[440px] flex flex-col items-center gap-[8px] md:gap-[10px] lg:gap-[12px]">
-          <a href="{{ next_url }}" class="w-full rounded-[6px] bg-[var(--brand-primary)] px-[24px] py-[20px] flex items-center justify-center gap-[20px]">
+          <a href="{{ next_url | campaign_link }}{{ cta_params }}" class="w-full rounded-[6px] bg-[var(--brand-primary)] px-[24px] py-[20px] flex items-center justify-center gap-[20px]">
             <span class="text-[20px] leading-[1.5] tracking-[-0.1px] font-bold text-white text-center">
               {{ cta_text }}
             </span>

--- a/src/landing/_includes/cta-1.html
+++ b/src/landing/_includes/cta-1.html
@@ -19,7 +19,7 @@
 <div class="cta-1-sticky bg-white shadow-[0_-4px_16px_rgba(0,0,0,0.12)]" data-cta-1-sticky>
   <div class="px-[15px] py-[12px] flex flex-col items-center gap-[8px]">
     <a
-      href="{{ next_url }}"
+      href="{{ next_url | campaign_link }}{{ cta_params }}"
       class="w-full max-w-[345px] bg-[var(--brand-primary)] rounded-[6px] px-[24px] py-[16px] flex items-center justify-center gap-[16px] no-underline"
     >
       <span class="font-bold text-[18px] leading-[1.5] tracking-[-0.09px] text-white text-center whitespace-nowrap">{{ cta_text }}</span>

--- a/src/landing/_includes/faq-1.html
+++ b/src/landing/_includes/faq-1.html
@@ -12,7 +12,7 @@
 
         <div class="hidden lg:flex w-[440px] flex-col items-center">
           <div class="w-full flex flex-col items-center gap-[12px]">
-            <a href="{{ next_url }}"
+            <a href="{{ next_url | campaign_link }}{{ cta_params }}"
                class="w-full bg-[var(--brand-primary)] rounded-[6px] py-[20px] px-[24px] flex items-center justify-center gap-[20px] no-underline">
               <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5] whitespace-nowrap">{{ cta_text | default: "Order Now" }}</span>
               <img src="{{ faq_1_cta_arrow | default: 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[16px] h-[12px] shrink-0" aria-hidden="true">
@@ -146,7 +146,7 @@
 
         <div class="w-[345px] md:w-[440px] flex flex-col items-center lg:hidden">
           <div class="w-full flex flex-col items-center gap-[12px]">
-            <a href="{{ next_url }}"
+            <a href="{{ next_url | campaign_link }}{{ cta_params }}"
                class="w-full bg-[var(--brand-primary)] rounded-[6px] py-[20px] px-[24px] flex items-center justify-center gap-[20px] no-underline">
               <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5] whitespace-nowrap">{{ cta_text | default: "Order Now" }}</span>
               <img src="{{ faq_1_cta_arrow | default: 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[16px] h-[12px] shrink-0" aria-hidden="true">

--- a/src/landing/_includes/hero-1.html
+++ b/src/landing/_includes/hero-1.html
@@ -65,7 +65,7 @@
         <!-- CTA block -->
         <div class="w-full md:max-w-[440px]">
           <div class="w-full flex flex-col items-center gap-[12px]">
-            <a href="{{ next_url }}"
+            <a href="{{ next_url | campaign_link }}{{ cta_params }}"
                class="w-full bg-[var(--brand-primary)] rounded-[6px] py-[20px] px-[24px] flex items-center justify-center gap-[20px] no-underline">
               <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5] whitespace-nowrap">{{ cta_text | default: "Order Now" }}</span>
               <img src="{{ cta_button_arrow | default: 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[16px] h-[12px] shrink-0" aria-hidden="true">

--- a/src/landing/_includes/ingredients-3.html
+++ b/src/landing/_includes/ingredients-3.html
@@ -217,7 +217,7 @@
       </div>
 
       <div class="w-[345px] md:w-[440px] flex flex-col items-center gap-[8px] md:gap-[10px] lg:gap-[12px]">
-        <a href="{{ next_url }}" class="w-full bg-[var(--brand-primary)] rounded-[6px] px-[24px] py-[20px] flex items-center justify-center gap-[20px] no-underline">
+        <a href="{{ next_url | campaign_link }}{{ cta_params }}" class="w-full bg-[var(--brand-primary)] rounded-[6px] px-[24px] py-[20px] flex items-center justify-center gap-[20px] no-underline">
           <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5]">{{ cta_text }}</span>
           <img src="{{ 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[12px] h-[16px] object-contain">
         </a>

--- a/src/landing/_includes/nav-1.html
+++ b/src/landing/_includes/nav-1.html
@@ -60,7 +60,7 @@
           <a href="{{ nav_1_nav_3_url }}" class="nav1-link relative font-bold text-[14px] lg:text-[16px] leading-none tracking-[-0.07px] lg:tracking-[-0.08px] text-[var(--text-primary)] pb-[8px]" data-nav1-link>{{ nav_1_nav_3_text }}<span class="nav1-link-indicator absolute left-0 right-0 -bottom-[4px] h-[4px] bg-[var(--brand-primary)]"></span></a>
         </nav>
 
-        <a href="{{ next_url }}" class="flex items-center gap-[12px]">
+        <a href="{{ next_url | campaign_link }}{{ cta_params }}" class="flex items-center gap-[12px]">
           <span class="font-extrabold text-[18px] leading-none tracking-[-0.09px] text-[var(--text-primary)] underline">{{ nav_1_cta_text }}</span>
           <img src="{{ nav_1_cta_flag | campaign_asset }}" alt="{{ nav_1_cta_flag_alt }}" class="w-[28px] h-[16px] lg:w-[32px] lg:h-[18px] object-cover">
         </a>

--- a/src/landing/_includes/problemsolution-1.html
+++ b/src/landing/_includes/problemsolution-1.html
@@ -62,7 +62,7 @@
 
       <!-- CTA -->
       <div class="w-[345px] md:w-[440px] flex flex-col items-center gap-[8px] md:gap-[10px] lg:gap-[12px]">
-        <a href="{{ next_url }}" class="w-full rounded-[6px] bg-[var(--brand-primary)] px-[24px] py-[20px] flex items-center justify-center gap-[20px]">
+        <a href="{{ next_url | campaign_link }}{{ cta_params }}" class="w-full rounded-[6px] bg-[var(--brand-primary)] px-[24px] py-[20px] flex items-center justify-center gap-[20px]">
           <span class="text-[20px] leading-[1.5] tracking-[-0.1px] font-bold text-white text-center">
             {{ cta_text }}
           </span>

--- a/src/landing/_includes/results-4.html
+++ b/src/landing/_includes/results-4.html
@@ -102,7 +102,7 @@
 
       <!-- CTA -->
       <div class="flex flex-col items-center gap-[8px] md:gap-[10px] lg:gap-[12px] w-full max-w-[440px]">
-        <a href="{{ next_url }}"
+        <a href="{{ next_url | campaign_link }}{{ cta_params }}"
           class="w-full bg-[var(--brand-primary)] rounded-[6px] py-[20px] px-[24px] flex items-center justify-center gap-[20px] no-underline">
             <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5] whitespace-nowrap">{{ cta_text }}</span>
             <img src="{{ 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[16px] h-[12px] shrink-0">

--- a/src/landing/_includes/testimonials-2.html
+++ b/src/landing/_includes/testimonials-2.html
@@ -125,7 +125,7 @@
 
       <!-- CTA -->
       <div class="flex flex-col items-center gap-[8px] md:gap-[10px] lg:gap-[12px] w-full max-w-[440px]">
-        <a href="{{ next_url }}"
+        <a href="{{ next_url | campaign_link }}{{ cta_params }}"
           class="w-full bg-[var(--brand-primary)] rounded-[6px] py-[20px] px-[24px] flex items-center justify-center gap-[20px] no-underline">
             <span class="font-bold text-[20px] text-white text-center tracking-[-0.1px] leading-[1.5] whitespace-nowrap">{{ cta_text }}</span>
             <img src="{{ 'images/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[16px] h-[12px] shrink-0">

--- a/src/landing/index.html
+++ b/src/landing/index.html
@@ -7,11 +7,13 @@ page_type: product
 
 # SHARED (component-level)
 next_url: "checkout.html"
-# cta_params is appended to every section CTA href (after the campaign_link filter).
-# Use it to preselect a package/bundle on the destination page, e.g. "?forcePackageId=1:1"
-# (the shop templates do this for selector-less checkouts). Empty by default — selector-based
-# checkouts let the shopper choose on-page, so nothing needs to be forced through the URL.
-cta_params: ""
+# cta_params is appended RAW to every section CTA href (after the campaign_link filter),
+# so a non-empty value MUST start with "?" — e.g. cta_params: "?forcePackageId=1:1".
+# Omitting the "?" produces a broken URL (checkout/forcePackageId=1:1).
+# Use it to preselect a package/bundle on the destination page (the shop templates do this
+# for selector-less checkouts). Empty by default — selector-based checkouts let the shopper
+# choose on-page, so nothing needs to be forced through the URL.
+cta_params: ""   # e.g. "?forcePackageId=1:1" (note the leading "?")
 cta_text: "Order Now & Save  60%"
 guarantee_text: "30 Day Money Back Guarantee"
 nav_logo_image: "images/nav-2/logo-next.svg"

--- a/src/landing/index.html
+++ b/src/landing/index.html
@@ -7,6 +7,11 @@ page_type: product
 
 # SHARED (component-level)
 next_url: "checkout.html"
+# cta_params is appended to every section CTA href (after the campaign_link filter).
+# Use it to preselect a package/bundle on the destination page, e.g. "?forcePackageId=1:1"
+# (the shop templates do this for selector-less checkouts). Empty by default — selector-based
+# checkouts let the shopper choose on-page, so nothing needs to be forced through the URL.
+cta_params: ""
 cta_text: "Order Now & Save  60%"
 guarantee_text: "30 Day Money Back Guarantee"
 nav_logo_image: "images/nav-2/logo-next.svg"


### PR DESCRIPTION
Addresses **D1.3** from the cross-family include-drift inventory (#64).

## What
Brings the canonical `landing` section library in line with the shop-template CTA pattern. Across the 9 sections that have CTA links (hero-1, cta-1, bottomcta-1, faq-1, nav-1, ingredients-3, problemsolution-1, results-4, testimonials-2):

```diff
- href="{{ next_url }}"
+ href="{{ next_url | campaign_link }}{{ cta_params }}"
```

Two improvements bundled:
1. **`| campaign_link`** — the correct 0.4.x clean-URL filter (the library was using bare `next_url`).
2. **`{{ cta_params }}`** — a query-string passthrough, documented in `index.html` frontmatter.

## Why keep cta_params here (it's shop-specific today)
`cta_params` (`?forcePackageId=1:1`) is currently only used by the two shop families, whose selector-less checkouts need to arrive with a package pre-selected. Selector-based families (olympus/demeter/limos/mv) pick the package on-page, so they don't need it.

It's kept in the **canonical section library as a reference**: a dev building a classical landing→checkout flow (or wanting to preselect a bundle) can use it. It's **empty by default**, so the showcase and any selector-based copy render unchanged.

## Scope note (re #64)
On inspection, D1.3 is closer to an **intentional shop variant** than unpropagated drift — but worth preserving in the library as a documented pattern rather than dropping. Other D1 items (receipt-skeleton, cart-summary03) turned out to be annotation-parity (D2) or mixed; those are not in this PR. Coupon normalization (D1.5) shipped separately in #68.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)