### PR TITLE
chore(demeter): comment FOMO initialDelay to match other families

### DIFF
--- a/src/demeter/assets/js/checkout.js
+++ b/src/demeter/assets/js/checkout.js
@@ -59,7 +59,7 @@ document.querySelectorAll('[data-next-element="timer"]').forEach(timer => {
 // Call inside a next:initialized event handler
 function initFomo() {
   next.fomo({
-    initialDelay: 5000,      // ms before first popup (default: 5000)
+    // initialDelay: 5000,      // ms before first popup (default: 5000)
     // displayDuration: 5000,   // ms popup stays visible (default: 5000)
     // delayBetween: 10000,     // ms between popups (default: 10000)
     // maxMobileShows: 5,       // max times to show on mobile (default: 5)


### PR DESCRIPTION
Addresses **D1.4** from the cross-family include-drift inventory (#64).

## What
Normalizes the `next.fomo()` `initialDelay` line in `checkout.js` across all 7 families. Demeter had it **active**; the other six kept it **commented**. This comments demeter's line so all seven match.

```diff
-    initialDelay: 5000,      // ms before first popup (default: 5000)
+    // initialDelay: 5000,      // ms before first popup (default: 5000)
```

## Why it's safe
`5000` is the SDK's built-in default (per the inline comment), so active-vs-commented is **purely cosmetic** — no behavioral change to the FOMO popup in any family.

## Note re #64
The issue described this as exit-intent `initialDelay` active in "demeter + limos" — on inspection it's actually the **FOMO popup** config, and only **demeter** had it active (limos was already commented). This PR reflects the real state.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)