### PR TITLE
style(olympus): align .os-card__title-badge property order with other families

### DIFF
--- a/src/olympus/assets/css/next-core.css
+++ b/src/olympus/assets/css/next-core.css
@@ -5046,6 +5046,7 @@ figcaption {
 }
 
 .os-card__title-badge {
+  width: fit-content;
   color: #000;
   text-transform: uppercase;
   background-color: #e2e2e2;
@@ -5053,7 +5054,6 @@ figcaption {
   padding: 4px .5rem;
   font-size: var(--font-size--xs);
   font-weight: 700;
-  width: fit-content;
 }
 
 .os-card__title-badge.pb--bestseller {


### PR DESCRIPTION
Addresses **D1.6** from the cross-family include-drift inventory (#64).

## What
`next-core.css` carried one `width: fit-content` declaration in a different position across families:
- **olympus**: `width: fit-content` was the **last** property of `.os-card__title-badge`
- **other 6 families**: it's the **first** property

This reorders olympus's declaration to match the majority.

```diff
 .os-card__title-badge {
+  width: fit-content;
   color: #000;
   text-transform: uppercase;
   background-color: #e2e2e2;
   border-radius: 6px;
   padding: 4px .5rem;
   font-size: var(--font-size--xs);
   font-weight: 700;
-  width: fit-content;
 }
```

## Why it's safe
Same rule, same property, same value — only the declaration order differed, so there is **no rendering change**. The `.os-card__title-badge` block is now byte-identical across all 7 families (verified by hashing the rule in each `next-core.css`).

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)