### PR TITLE
chore: standardize include contract headers on {% comment %} (no HTML-comment leaks)

### DIFF
--- a/src/demeter/_includes/receipt-order-summary-desktop.html
+++ b/src/demeter/_includes/receipt-order-summary-desktop.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: demeter-receipt-order-summary-desktop
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, desktop_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/demeter/_includes/receipt-order-summary-mobile.html
+++ b/src/demeter/_includes/receipt-order-summary-mobile.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: demeter-receipt-order-summary-mobile
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, mobile_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/demeter/_includes/upsell-bundle-stepper-offer.html
+++ b/src/demeter/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/demeter/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/limos/_includes/receipt-order-summary-desktop.html
+++ b/src/limos/_includes/receipt-order-summary-desktop.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: limos-receipt-order-summary-desktop
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, desktop_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/limos/_includes/receipt-order-summary-mobile.html
+++ b/src/limos/_includes/receipt-order-summary-mobile.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: limos-receipt-order-summary-mobile
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, mobile_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/limos/_includes/upsell-bundle-stepper-offer.html
+++ b/src/limos/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/limos/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/limos/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/limos/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/limos/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-single-step/_includes/upsell-bundle-stepper-offer.html
+++ b/src/olympus-mv-single-step/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-single-step/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/olympus-mv-single-step/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-single-step/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/olympus-mv-single-step/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-single-step/_includes/upsell-mv-offer.html
+++ b/src/olympus-mv-single-step/_includes/upsell-mv-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: mv-configurable-upsell-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, bundle slots, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display_selector_id, display_bundle_id, accept/decline text.
     upsell_mv_tiers: array. Bundle card ids, quantity, vouchers, selected state.
   next_dont_touch: data-next-bundle-*, data-next-bundle-slots-for, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 1 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-two-step/_includes/upsell-bundle-stepper-offer.html
+++ b/src/olympus-mv-two-step/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-two-step/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/olympus-mv-two-step/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-two-step/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/olympus-mv-two-step/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus-mv-two-step/_includes/upsell-mv-offer.html
+++ b/src/olympus-mv-two-step/_includes/upsell-mv-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: mv-configurable-upsell-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, bundle slots, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display_selector_id, display_bundle_id, accept/decline text.
     upsell_mv_tiers: array. Bundle card ids, quantity, vouchers, selected state.
   next_dont_touch: data-next-bundle-*, data-next-bundle-slots-for, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 1 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus/_includes/upsell-bundle-stepper-offer.html
+++ b/src/olympus/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/olympus/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/olympus/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/olympus/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-single-step/_includes/receipt-order-summary-desktop.html
+++ b/src/shop-single-step/_includes/receipt-order-summary-desktop.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: shop-single-step-receipt-order-summary-desktop
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, desktop_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/shop-single-step/_includes/receipt-order-summary-mobile.html
+++ b/src/shop-single-step/_includes/receipt-order-summary-mobile.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: shop-single-step-receipt-order-summary-mobile
   next_version: 1
   next_sdk_owns: receipt order item template and data-next-order-items target
@@ -7,7 +7,7 @@
     receipt_summary: object. title, scroll_hint, mobile_item_template_id.
     item_template_id: string override for the SDK order-line template id.
   next_dont_touch: data-next-order-items and data-item-template-id must reference the same template id.
--->
+{% endcomment %}
 {% assign summary = receipt_summary -%}
 {% assign summary_title = summary.title | default: 'Order Summary' -%}
 {% assign scroll_hint = scroll_hint | default: summary.scroll_hint | default: 'Scroll for more items' -%}

--- a/src/shop-single-step/_includes/upsell-bundle-stepper-offer.html
+++ b/src/shop-single-step/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-single-step/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/shop-single-step/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-single-step/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/shop-single-step/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-three-step/_includes/upsell-bundle-stepper-offer.html
+++ b/src/shop-three-step/_includes/upsell-bundle-stepper-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-stepper-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -6,7 +6,7 @@
   next_params:
     upsell_offer: object. package_id, selector_id, bundle_id, items_json, vouchers_json, quantity bounds, accept/decline text.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-three-step/_includes/upsell-bundle-tier-cards-offer.html
+++ b/src/shop-three-step/_includes/upsell-bundle-tier-cards-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-cards-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Visible bundle card ids, item JSON, vouchers, labels, hints, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}

--- a/src/shop-three-step/_includes/upsell-bundle-tier-pills-offer.html
+++ b/src/shop-three-step/_includes/upsell-bundle-tier-pills-offer.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   next_component: upsell-bundle-tier-pills-offer
   next_version: 1
   next_sdk_owns: bundle selector, bundle cards, quantity control, upsell add/skip actions
@@ -7,7 +7,7 @@
     upsell_offer: object. package_id, selector_id, display selector ids, accept/decline text.
     upsell_bundle_tiers: array. Bundle card ids, item JSON, vouchers, quantity button value, selected state.
   next_dont_touch: data-next-bundle-*, data-next-quantity-*, data-next-upsell-*
--->
+{% endcomment %}
 {% assign offer = upsell_offer -%}
 {% assign package_id = offer.package_id | default: 3 -%}
 {% assign selector_id = offer.selector_id | default: 'upsell-bundle' -%}


### PR DESCRIPTION
Part of **D2** (annotation parity) on #64 — the comment-syntax standardization slice.

## Problem
Several includes carried their `next_component:` contract headers as HTML `<!-- -->` comments, which **ship the documentation into production page source**. `{% comment %}` blocks are stripped at build time; HTML comments are not.

## Change
Convert the leading contract header from `<!-- -->` to `{% comment %}` / `{% endcomment %}` in:
- **23 `upsell-*-offer` includes** (all families): `upsell-bundle-stepper-offer`, `upsell-bundle-tier-cards-offer`, `upsell-bundle-tier-pills-offer`, and the mv `upsell-mv-offer`
- **6 `receipt-order-summary-desktop/mobile` includes** (demeter, limos, shop-single-step)

Only the leading header comment is converted; inline body HTML comments are intentionally left as-is.

## Verification
- `npm run build` → 55 pages, no errors
- A full build now contains **zero** `next_component` strings in `_site/` output (previously these headers leaked into shipped HTML)

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)