### PR TITLE
chore: annotation parity for body-identical includes (receipt-skeleton, cart-summary01/02/04, express-checkout)

### DIFF
--- a/src/demeter/_includes/cart-summary01.html
+++ b/src/demeter/_includes/cart-summary01.html
@@ -1,4 +1,36 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/demeter/_includes/cart-summary02.html
+++ b/src/demeter/_includes/cart-summary02.html
@@ -1,4 +1,44 @@
-<div data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">
       <div class="order-summary__accordion-head">

--- a/src/demeter/_includes/cart-summary04.html
+++ b/src/demeter/_includes/cart-summary04.html
@@ -1,4 +1,34 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Large image-line order summary panel showing variant imagery, line items, discounts, shipping, and totals (Olympus variant 04).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart and package display values)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.variantName} is intentional for multi-variant carts; use {item.name} only for single-variant summaries
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (stacked default)
+    - 02 (accordion variant)
+    - 03 (compact featured product)
+    - 04 (this; large/image-line variant)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">

--- a/src/demeter/_includes/express-checkout.html
+++ b/src/demeter/_includes/express-checkout.html
@@ -1,3 +1,29 @@
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
 <div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>

--- a/src/demeter/_includes/receipt-skeleton.html
+++ b/src/demeter/_includes/receipt-skeleton.html
@@ -1,8 +1,25 @@
-<div
-  data-next-catalog-component="receipt-skeleton"
-  data-next-skeleton=""
-  class="skeleton-wrapper"
->
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/limos/_includes/cart-summary01.html
+++ b/src/limos/_includes/cart-summary01.html
@@ -1,4 +1,36 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/limos/_includes/cart-summary02.html
+++ b/src/limos/_includes/cart-summary02.html
@@ -1,3 +1,43 @@
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
 <div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">

--- a/src/limos/_includes/cart-summary04.html
+++ b/src/limos/_includes/cart-summary04.html
@@ -1,4 +1,34 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Large image-line order summary panel showing variant imagery, line items, discounts, shipping, and totals (Olympus variant 04).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart and package display values)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.variantName} is intentional for multi-variant carts; use {item.name} only for single-variant summaries
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (stacked default)
+    - 02 (accordion variant)
+    - 03 (compact featured product)
+    - 04 (this; large/image-line variant)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">

--- a/src/limos/_includes/express-checkout.html
+++ b/src/limos/_includes/express-checkout.html
@@ -1,4 +1,30 @@
-<div data-next-express-checkout="container" class="exp-checkout">
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
+<div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>
   {% endif %}

--- a/src/limos/_includes/receipt-skeleton.html
+++ b/src/limos/_includes/receipt-skeleton.html
@@ -1,8 +1,25 @@
-<div
-  data-next-catalog-component="receipt-skeleton"
-  data-next-skeleton=""
-  class="skeleton-wrapper"
->
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/olympus-mv-single-step/_includes/cart-summary01.html
+++ b/src/olympus-mv-single-step/_includes/cart-summary01.html
@@ -1,3 +1,35 @@
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
 <div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/olympus-mv-single-step/_includes/cart-summary02.html
+++ b/src/olympus-mv-single-step/_includes/cart-summary02.html
@@ -1,4 +1,44 @@
-<div data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">
       <div class="order-summary__accordion-head">

--- a/src/olympus-mv-single-step/_includes/cart-summary04.html
+++ b/src/olympus-mv-single-step/_includes/cart-summary04.html
@@ -1,4 +1,34 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Large image-line order summary panel showing variant imagery, line items, discounts, shipping, and totals (Olympus variant 04).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart and package display values)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.variantName} is intentional for multi-variant carts; use {item.name} only for single-variant summaries
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (stacked default)
+    - 02 (accordion variant)
+    - 03 (compact featured product)
+    - 04 (this; large/image-line variant)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">

--- a/src/olympus-mv-single-step/_includes/express-checkout.html
+++ b/src/olympus-mv-single-step/_includes/express-checkout.html
@@ -1,4 +1,30 @@
-<div data-next-express-checkout="container" class="exp-checkout">
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
+<div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>
   {% endif %}

--- a/src/olympus-mv-single-step/_includes/receipt-skeleton.html
+++ b/src/olympus-mv-single-step/_includes/receipt-skeleton.html
@@ -1,3 +1,24 @@
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
 <div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">

--- a/src/olympus-mv-two-step/_includes/cart-summary01.html
+++ b/src/olympus-mv-two-step/_includes/cart-summary01.html
@@ -1,4 +1,36 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/olympus-mv-two-step/_includes/cart-summary02.html
+++ b/src/olympus-mv-two-step/_includes/cart-summary02.html
@@ -1,4 +1,44 @@
-<div data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">
       <div class="order-summary__accordion-head">

--- a/src/olympus-mv-two-step/_includes/cart-summary04.html
+++ b/src/olympus-mv-two-step/_includes/cart-summary04.html
@@ -1,3 +1,33 @@
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Large image-line order summary panel showing variant imagery, line items, discounts, shipping, and totals (Olympus variant 04).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart and package display values)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.variantName} is intentional for multi-variant carts; use {item.name} only for single-variant summaries
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (stacked default)
+    - 02 (accordion variant)
+    - 03 (compact featured product)
+    - 04 (this; large/image-line variant)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
 <div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">

--- a/src/olympus-mv-two-step/_includes/express-checkout.html
+++ b/src/olympus-mv-two-step/_includes/express-checkout.html
@@ -1,4 +1,30 @@
-<div data-next-express-checkout="container" class="exp-checkout">
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
+<div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>
   {% endif %}

--- a/src/olympus-mv-two-step/_includes/receipt-skeleton.html
+++ b/src/olympus-mv-two-step/_includes/receipt-skeleton.html
@@ -1,3 +1,24 @@
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
 <div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">

--- a/src/shop-single-step/_includes/cart-summary01.html
+++ b/src/shop-single-step/_includes/cart-summary01.html
@@ -1,4 +1,36 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/shop-single-step/_includes/cart-summary02.html
+++ b/src/shop-single-step/_includes/cart-summary02.html
@@ -1,4 +1,44 @@
-<div data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">
       <div class="order-summary__accordion-head">

--- a/src/shop-single-step/_includes/express-checkout.html
+++ b/src/shop-single-step/_includes/express-checkout.html
@@ -1,3 +1,29 @@
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
 <div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>

--- a/src/shop-single-step/_includes/receipt-skeleton.html
+++ b/src/shop-single-step/_includes/receipt-skeleton.html
@@ -1,8 +1,25 @@
-<div
-  data-next-catalog-component="receipt-skeleton"
-  data-next-skeleton=""
-  class="skeleton-wrapper"
->
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
+<div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">
       <div class="checkout__layout">

--- a/src/shop-three-step/_includes/cart-summary01.html
+++ b/src/shop-three-step/_includes/cart-summary01.html
@@ -1,4 +1,36 @@
-<div class="summary-wrapper" data-next-cart-summary>
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Stacked order summary panel showing line items, discounts, shipping, totals. Default Olympus checkout summary (variant 01).
+  next_params: (none today; parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-cart-summary
+    - data-summary-lines (single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage, etc)
+    - data-next-show / data-next-hide (cart.hasDiscounts, item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.summary-wrapper, .order-summary, .order-summary__content, .cart-items, .cart-item, .order-totals]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount
+    - {item.hasDiscount} resolves to CSS class string ("hide" or empty), not boolean
+  next_gotchas:
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+    - Tax token {tax} is intentionally not rendered — not wired in CartSummaryEnhancer (BS-017)
+  next_variants:
+    - 01 (this; stacked default for Olympus)
+    - 02 (accordion variant)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents)
+    - submit-block (acts on the totals)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" class="summary-wrapper" data-next-cart-summary>
   <template>
     <div class="order-summary">
       <div class="order-summary__content">
@@ -57,6 +89,7 @@
                   <div class="order-totals__label text-muted">{discount.name} - Save {discount.percentage}</div>
                   <div class="order-totals__value text-muted">−{discount.amount}</div>
                 </li>
+                
               </template>
             </ul>
             <ul class="order-totals__discount-list" data-next-discounts="voucher" aria-label="Coupon discounts">

--- a/src/shop-three-step/_includes/cart-summary02.html
+++ b/src/shop-three-step/_includes/cart-summary02.html
@@ -1,4 +1,44 @@
-<div data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
+{% comment %}
+  next_component: order-summary
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Accordion-style order summary panel showing line items, discounts, shipping, taxes, and grand total. Customer can toggle visibility on small screens.
+  next_params: (none today; full parameterization deferred to v1)
+  next_sdk_owns:
+    - data-next-accordion (order-summary)
+    - data-next-accordion-trigger
+    - data-next-accordion-text
+    - data-next-accordion-panel
+    - data-next-cart-summary
+    - data-summary-lines (with single-brace tokens: {item.*}, {subtotal}, {shipping}, {discounts}, {currency}, {total})
+    - data-next-discounts (offer / voucher)
+    - data-next-display (cart.totalDiscountPercentage)
+    - data-next-show (cart.hasDiscounts)
+    - data-next-show / data-next-hide (item.isRecurring)
+    - data-next-component="scroll-hint"
+  next_theming:
+    classes_designer_owns: [.order-summary__accordion, .order-summary__accordion-trigger, .order-summary__accordion-panel, .summary-toggle__text, .cart-items, .cart-item, .order-totals, .order-totals__line, .order-totals__label, .order-totals__value, .badge, .summary-total__coin]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Single-brace tokens inside <template> are SDK syntax, not Liquid; do not change to {{ }}
+    - {item.price} is line total AFTER discounts; {item.originalPrice} is pre-discount; {item.unitPrice} is per-unit
+    - {item.hasDiscount} resolves to a CSS class string (e.g. "hide" when no discount), not a boolean
+    - {tax} token is intentionally hidden (BS-017: not wired in CartSummaryEnhancer); do NOT enable
+    - Discount row uses data-next-show="cart.hasDiscounts" — auto-hides when zero
+  next_gotchas:
+    - Two <template> levels: outer holds the line-item structure, inner is per-item
+    - Voucher row {discount.name} expects vouchers from Campaign Offers, not fake package IDs
+    - cart.totalDiscountPercentage rounds to nearest integer for display
+  next_variants:
+    - 01 (default-stacked)
+    - 02 (this; accordion with scroll-hint)
+    - 03 (compact)
+    - 04 (large)
+  next_related:
+    - bundle-selector (drives cart contents this summary renders)
+    - submit-block (acts on the totals shown here)
+{% endcomment %}
+<div data-next-catalog-component="order-summary" data-initial-state="closed" data-next-accordion="order-summary" data-open-text="Hide Order Summary" data-close-text="Show Order Summary" data-toggle-class="next-expanded" class="order-summary__accordion">
   <div data-next-accordion-trigger="order-summary" class="order-summary__accordion-trigger">
     <div class="order-summary__accordion-inner">
       <div class="order-summary__accordion-head">

--- a/src/shop-three-step/_includes/express-checkout.html
+++ b/src/shop-three-step/_includes/express-checkout.html
@@ -1,3 +1,29 @@
+{% comment %}
+  next_component: payment-method-presentation
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Express-checkout button bar (PayPal / Apple Pay / Google Pay / Klarna). Skips the credit card form entirely. Sub-surface of payment-method-presentation; included alongside payment-methods.html.
+  next_params:
+    show_title:   bool, default true. Set to false to hide the "Express Checkout" heading.
+  next_sdk_owns:
+    - data-next-express-checkout (values: container, paypal, apple-pay, google-pay, klarna)
+    - data-next-component (express-error, express-error-text)
+  next_theming:
+    classes_designer_owns: [.exp-checkout, .express-checkout__title, .express-checkout__buttons, .next-toast-handler]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - Each express button is a SDK-mounted iframe; do not wrap in extra elements that change layout box model
+    - Express method visibility is gated by paymentConfig.expressCheckout in nextConfig — flag mismatches
+  next_gotchas:
+    - Stacked layout (this) vs inline (express-checkout-inline.html) — pick one per page; do not mix
+    - "Or" divider between express bar and credit form is purely visual; SDK behavior identical
+  next_variants:
+    - stacked (this; full-width button stack)
+    - inline (express-checkout-inline.html; compact horizontal bar)
+  next_related:
+    - express-checkout-inline.html (compact variant)
+    - payment-methods.html (the sibling credit card form)
+{% endcomment %}
 <div data-next-catalog-component="express-checkout" data-next-express-checkout="container" class="exp-checkout">
   {% if show_title != false %}
   <div class="express-checkout__title">Express Checkout</div>

--- a/src/shop-three-step/_includes/receipt-skeleton.html
+++ b/src/shop-three-step/_includes/receipt-skeleton.html
@@ -1,3 +1,24 @@
+{% comment %}
+  next_component: receipt-skeleton
+  next_version: 1.0.0
+  next_sdk_min: 0.4.18
+  next_purpose: Loading skeleton for the receipt page. Renders before SDK hydrates order data; SDK swaps for real content once next-display-ready fires.
+  next_params: (none today)
+  next_sdk_owns:
+    - data-next-skeleton
+    - next-display-ready (class added to <html> when SDK is ready)
+  next_theming:
+    classes_designer_owns: [.skeleton-wrapper, .skeleton-line, .skeleton-block]
+    css_vars_designer_owns: []
+  next_dont_touch:
+    - SDK hides this wrapper once order data renders; do not animate transitions in CSS that conflict with SDK display swap
+  next_gotchas:
+    - Skeleton dimensions should approximate real receipt layout to prevent CLS (cumulative layout shift)
+  next_variants:
+    - default (this)
+  next_related:
+    - data-next-order-items (real receipt content this skeleton precedes)
+{% endcomment %}
 <div data-next-catalog-component="receipt-skeleton" data-next-skeleton="" class="skeleton-wrapper">
   <div class="checkout-content">
     <div class="checkout__content">


### PR DESCRIPTION
Part of **D2** (annotation parity) on #64 — the "clean batch" where sibling includes were already functionally identical to olympus and just needed the contract header (and the matching `data-next-catalog-component` marker).

## Change
Propagate olympus's `next_component:` `{% comment %}` headers + `data-next-catalog-component` marker to sibling families, bringing each include to full byte-parity:

| Include | Result |
|---|---|
| `receipt-skeleton` | all 7 families identical (folds in **D1.7** — the "two variants" were only the header + `<div>` formatting) |
| `cart-summary01` | all 7 families identical |
| `cart-summary02` | all 7 families identical |
| `express-checkout` | all 7 families identical |
| `cart-summary04` | olympus + 4 non-shop families identical; **shop pair left untouched** (intentional 133-line D3 rewrite variant) |

Before this, the only real difference between olympus and the siblings for these includes was the missing `data-next-catalog-component` marker attribute (+ trailing whitespace) — so this also resolves the catalog-marker drift ("Slice C") for them.

## Verification
- `npm run build` → 55 pages, no errors
- Headers strip from shipped HTML (they're `{% comment %}` blocks)

## Not included (separate work on #64)
- `payment-methods` — that delta is **D1.2** (olympus extracted `billing-address-form.html`; 6 families still inline it) → its own PR
- `cart-summary03`, `bump-check01`, `cart-summary04` shop pair — **D3** intentional variant lineages → headers authored per-variant

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)