### PR TITLE
docs(catalog): name intentional shared-include variants (D3)

### DIFF
--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -1403,11 +1403,11 @@
         "surface": "orderSummary",
         "lineages": [
           { "families": ["olympus", "demeter", "limos", "olympus-mv-single-step", "olympus-mv-two-step"], "note": "Large/image-line order summary (annotated in #73)." },
-          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop rewrite of cart-summary04 (~133-line structural difference)." }
+          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop structural rewrite of cart-summary04 (188 lines vs olympus's 143)." }
         ]
       },
       "checkout-footer-links.html": {
-        "surface": "footer",
+        "surface": "footerLinks",
         "lineages": [
           { "families": ["shop-single-step", "shop-three-step"], "note": "Shop footer links." },
           { "families": ["limos"], "note": "Limos footer links." }

--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -1359,5 +1359,67 @@
       }
     }
   },
-  "askUserPromptTemplate": "I can map this design to more than one commerce template family: {candidates}. The ambiguous surfaces are {surfaces}. Which family should I use before wiring SDK components?"
+  "askUserPromptTemplate": "I can map this design to more than one commerce template family: {candidates}. The ambiguous surfaces are {surfaces}. Which family should I use before wiring SDK components?",
+  "intentionalVariants": {
+    "purpose": "Shared includes that legitimately differ across families. These lineages are DELIBERATE design/structure differences, not drift — do NOT flag or auto-reconcile them in cross-family include-drift audits. Families omitted from an include's lineages do not ship that include.",
+    "verified": "2026-06-15",
+    "regenerate": "For each include, hash the body across families with the next_component/HTML-comment header and whitespace stripped; families with the same hash share a lineage.",
+    "doNotReconcile": true,
+    "includes": {
+      "bump-check01.html": {
+        "surface": "orderBump",
+        "lineages": [
+          { "families": ["olympus"], "note": "Olympus single-package check-style bump." },
+          { "families": ["olympus-mv-single-step", "olympus-mv-two-step"], "note": "MV/configurable bump: quantity sync via data-next-product-sync (product_id), so it sums across variant swaps (SDK 0.4.25+). See CLAUDE.md." },
+          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop bump layout for selector-less checkouts." },
+          { "families": ["demeter", "limos"], "note": "Editorial/Limos bump styling." }
+        ]
+      },
+      "bump-switch01.html": {
+        "surface": "orderBump",
+        "lineages": [
+          { "families": ["demeter", "limos"], "note": "Switch-style bump with demeter/limos styling." },
+          { "families": ["olympus", "olympus-mv-single-step", "olympus-mv-two-step", "shop-single-step", "shop-three-step"], "note": "Shared switch-style bump." }
+        ]
+      },
+      "checkout-header.html": {
+        "surface": "checkoutHeader",
+        "lineages": [
+          { "families": ["olympus", "olympus-mv-single-step", "olympus-mv-two-step"], "note": "Olympus/MV header." },
+          { "families": ["demeter"], "note": "Demeter header." },
+          { "families": ["limos"], "note": "Limos header." },
+          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop top-bar header (checkout-header--lg). See CLAUDE.md shop checkout top-bar notes." }
+        ]
+      },
+      "cart-summary03.html": {
+        "surface": "orderSummary",
+        "lineages": [
+          { "families": ["olympus"], "note": "Olympus featured-product order summary (annotated reference)." },
+          { "families": ["limos", "olympus-mv-single-step", "olympus-mv-two-step", "shop-single-step", "shop-three-step"], "note": "Shared featured-product summary body." },
+          { "families": ["demeter"], "note": "Demeter side-cart summary, parameterized (heading/subtitle/feature_package)." }
+        ]
+      },
+      "cart-summary04.html": {
+        "surface": "orderSummary",
+        "lineages": [
+          { "families": ["olympus", "demeter", "limos", "olympus-mv-single-step", "olympus-mv-two-step"], "note": "Large/image-line order summary (annotated in #73)." },
+          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop rewrite of cart-summary04 (~133-line structural difference)." }
+        ]
+      },
+      "checkout-footer-links.html": {
+        "surface": "footer",
+        "lineages": [
+          { "families": ["shop-single-step", "shop-three-step"], "note": "Shop footer links." },
+          { "families": ["limos"], "note": "Limos footer links." }
+        ]
+      },
+      "footer.html": {
+        "surface": "footer",
+        "lineages": [
+          { "families": ["olympus", "limos", "olympus-mv-single-step", "olympus-mv-two-step", "shop-single-step", "shop-three-step"], "note": "Shared footer." },
+          { "families": ["demeter"], "note": "Demeter footer (cc-medium variant)." }
+        ]
+      }
+    }
+  }
 }

--- a/docs/commerce-surface-catalog.md
+++ b/docs/commerce-surface-catalog.md
@@ -161,3 +161,17 @@ The goal is not a small fixed set of templates. The goal is a growing library of
 - `node scripts/lint-sdk.mjs --scope=demeter --pages=all` covers checkout, upsell, and receipt pages for `demeter`.
 
 Use `npm run lint:sdk:promoted:all` for a promoted-family all-page check during focused catalog work; CI already runs the full all-family all-page SDK lint.
+
+## Intentional Variants (not drift)
+
+Some shared includes legitimately differ across families by design. These lineages are **deliberate** — do **not** flag or auto-reconcile them in cross-family include-drift audits. (Machine-readable copy lives under `intentionalVariants` in `commerce-surface-catalog.json`.) Families not listed for an include do not ship that include. Verified 2026-06-15; regenerate by hashing each include body across families with the `next_component`/HTML-comment header and whitespace stripped — matching hashes share a lineage.
+
+| Include | Lineages (families that share one body) |
+|---|---|
+| `bump-check01.html` | **olympus** · **mv-pair** (mv-single + mv-two; uses `data-next-product-sync` for variant-safe qty sync) · **shop-pair** (shop-single + shop-three) · **demeter + limos** |
+| `bump-switch01.html` | **demeter + limos** · **rest** (olympus, mv-pair, shop-pair) |
+| `checkout-header.html` | **olympus + mv-pair** · **demeter** · **limos** · **shop-pair** (`checkout-header--lg` top bar) |
+| `cart-summary03.html` | **olympus** (reference) · **limos + mv-pair + shop-pair** (shared body) · **demeter** (parameterized: heading/subtitle/feature_package) |
+| `cart-summary04.html` | **olympus + demeter + limos + mv-pair** · **shop-pair** (~133-line shop rewrite) |
+| `checkout-footer-links.html` | **shop-pair** · **limos** (only these 3 families ship it) |
+| `footer.html` | **rest** (olympus, limos, mv-pair, shop-pair) · **demeter** (`cc-medium` variant) |

--- a/docs/commerce-surface-catalog.md
+++ b/docs/commerce-surface-catalog.md
@@ -172,6 +172,6 @@ Some shared includes legitimately differ across families by design. These lineag
 | `bump-switch01.html` | **demeter + limos** · **rest** (olympus, mv-pair, shop-pair) |
 | `checkout-header.html` | **olympus + mv-pair** · **demeter** · **limos** · **shop-pair** (`checkout-header--lg` top bar) |
 | `cart-summary03.html` | **olympus** (reference) · **limos + mv-pair + shop-pair** (shared body) · **demeter** (parameterized: heading/subtitle/feature_package) |
-| `cart-summary04.html` | **olympus + demeter + limos + mv-pair** · **shop-pair** (~133-line shop rewrite) |
+| `cart-summary04.html` | **olympus + demeter + limos + mv-pair** · **shop-pair** (shop structural rewrite, 188 vs 143 lines) |
 | `checkout-footer-links.html` | **shop-pair** · **limos** (only these 3 families ship it) |
 | `footer.html` | **rest** (olympus, limos, mv-pair, shop-pair) · **demeter** (`cc-medium` variant) |

--- a/scripts/lint-agent-contracts.mjs
+++ b/scripts/lint-agent-contracts.mjs
@@ -105,6 +105,48 @@ for (const family of expectedFamilies) {
   }
 }
 
+validateIntentionalVariants();
+
+function validateIntentionalVariants() {
+  const iv = catalog.intentionalVariants;
+  if (!iv || typeof iv !== 'object') {
+    errors.push('catalog.intentionalVariants: missing intentionalVariants block');
+    return;
+  }
+  for (const key of ['purpose', 'verified', 'regenerate', 'doNotReconcile', 'includes']) {
+    if (!(key in iv)) errors.push(`catalog.intentionalVariants.${key}: missing`);
+  }
+  const allowedSurfaces = ['orderBump', 'orderSummary', 'checkoutHeader', 'footer', 'footerLinks'];
+  if (!iv.includes || typeof iv.includes !== 'object') {
+    errors.push('catalog.intentionalVariants.includes: expected an object');
+    return;
+  }
+  for (const [inc, spec] of Object.entries(iv.includes)) {
+    const label = `catalog.intentionalVariants.includes.${inc}`;
+    if (!allowedSurfaces.includes(spec.surface)) {
+      errors.push(`${label}.surface: "${spec.surface}" not in [${allowedSurfaces.join(', ')}]`);
+    }
+    if (!Array.isArray(spec.lineages) || spec.lineages.length === 0) {
+      errors.push(`${label}.lineages: expected a non-empty array`);
+      continue;
+    }
+    for (const [i, lineage] of spec.lineages.entries()) {
+      if (!Array.isArray(lineage.families) || lineage.families.length === 0) {
+        errors.push(`${label}.lineages[${i}].families: expected a non-empty array`);
+      } else {
+        for (const fam of lineage.families) {
+          if (!expectedFamilies.includes(fam)) {
+            errors.push(`${label}.lineages[${i}].families: unknown family "${fam}"`);
+          }
+        }
+      }
+      if (typeof lineage.note !== 'string' || !lineage.note) {
+        errors.push(`${label}.lineages[${i}].note: expected a non-empty string`);
+      }
+    }
+  }
+}
+
 function walkFiles(dir, files = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = join(dir, entry.name);


### PR DESCRIPTION
Addresses **D3** from #64 — name intentional shared-include variants in the commerce-surface catalog so agents/reviewers stop treating deliberate differences as drift.

## What
- New `intentionalVariants` block in `docs/commerce-surface-catalog.json` (machine-readable; `doNotReconcile: true`)
- Mirror table in `docs/commerce-surface-catalog.md`

Documents the verified lineages for 7 shared includes:

| Include | Lineages |
|---|---|
| `bump-check01` | olympus · mv-pair · shop-pair · demeter+limos |
| `bump-switch01` | demeter+limos · rest |
| `checkout-header` | olympus+mv-pair · demeter · limos · shop-pair |
| `cart-summary03` | olympus · limos+mv-pair+shop-pair · demeter (parameterized) |
| `cart-summary04` | rest · shop-pair (133-line rewrite) |
| `checkout-footer-links` | shop-pair · limos |
| `footer` | rest · demeter (cc-medium) |

## How lineages were derived
Content-hashed each include body across families with the `next_component`/HTML-comment header and whitespace stripped — matching hashes share a lineage. Declared families cross-checked against disk (exact match, no missing/extra). `npm run lint:agent-contracts` passes.

## Closes #64
With D1 (all items) and D2 (Slice A + clean batch) merged, this D3 documentation completes the drift inventory. Genuinely-divergent includes are now recorded as intentional rather than pending reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)