### PR TITLE
fix + refactor: bump-switch title bug, generic bump defaults, parameterized mv/shop bump-check01

### DIFF
--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -8,7 +8,7 @@
     order_bump.check01: optional frontmatter object for package_id, sync_quantity, title, image_src, and features.
     package_id:         number, default 7.
     sync_quantity:      number, default 1. data-next-package-sync value.
-    title:              string, default "Get Extended Warranty".
+    title:              string, default "Order Bump Title".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
     show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
@@ -28,7 +28,7 @@
 {% assign bump = order_bump.check01 -%}
 {% assign pkg_id = package_id | default: packages.prepurchase_1 | default: bump.package_id | default: 7 -%}
 {% assign sync_qty = sync_quantity | default: bump.sync_quantity | default: packages.main_package | default: 1 -%}
-{% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
@@ -83,19 +83,19 @@
 	                {% else %}
 	                <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
 	                <li class="list__item">
 	                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-	                  <div>24/7 Priority Customer Support</div>
+	                  <div>Order bump feature 4</div>
 	                </li>
 	                {% endif %}
 	              </ul>

--- a/src/demeter/_includes/bump-check02.html
+++ b/src/demeter/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/demeter/_includes/bump-switch01.html
+++ b/src/demeter/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    title:               string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/limos/_includes/bump-check01.html
+++ b/src/limos/_includes/bump-check01.html
@@ -8,7 +8,7 @@
     order_bump.check01: optional frontmatter object for package_id, sync_quantity, title, image_src, and features.
     package_id:         number, default 7.
     sync_quantity:      number, default 1. data-next-package-sync value.
-    title:              string, default "Get Extended Warranty".
+    title:              string, default "Order Bump Title".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
     show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
@@ -28,7 +28,7 @@
 {% assign bump = order_bump.check01 -%}
 {% assign pkg_id = package_id | default: packages.prepurchase_1 | default: bump.package_id | default: 7 -%}
 {% assign sync_qty = sync_quantity | default: bump.sync_quantity | default: packages.main_package | default: 1 -%}
-{% assign bump_title = bump.title | default: 'Get Extended Warranty' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
@@ -83,19 +83,19 @@
 	                {% else %}
 	                <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
 	                <li class="list__item">
 	                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-	                  <div>24/7 Priority Customer Support</div>
+	                  <div>Order bump feature 4</div>
 	                </li>
 	                {% endif %}
 	              </ul>

--- a/src/limos/_includes/bump-check02.html
+++ b/src/limos/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/limos/_includes/bump-switch01.html
+++ b/src/limos/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    title:               string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,5 +1,8 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+{% assign bump = order_bump.check01 -%}
+{% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign feature_list = features | default: bump.features -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
@@ -23,7 +26,7 @@
           <div class="bump__checkbox">
             <div os-component="check" class="checkbox__icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--fe" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6 10l-2 2l6 6L20 8l-2-2l-8 8z"></path></svg></div>
           </div>
-          <div class="bump__title">Get Extended Warranty</div>
+          <div class="bump__title">{{ t }}</div>
         </div>
       </div>
       <!-- Bump body: price, list, image -->
@@ -48,22 +51,31 @@
             </div>
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">
+                {% if feature_list -%}
+                {% for feat in feature_list -%}
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>{{ feat }}</div>
+                </li>
+                {% endfor -%}
+                {% else -%}
+                <li class="list__item">
+                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>24/7 Priority Customer Support</div>
+                  <div>Order bump feature 4</div>
                 </li>
+                {% endif -%}
               </ul>
             </div>
           </div>

--- a/src/olympus-mv-single-step/_includes/bump-check02.html
+++ b/src/olympus-mv-single-step/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/olympus-mv-single-step/_includes/bump-switch01.html
+++ b/src/olympus-mv-single-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Shipping Insurance & Loss Prevention".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,7 +21,7 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
 {% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">

--- a/src/olympus-mv-single-step/_includes/bump-switch01.html
+++ b/src/olympus-mv-single-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    bump_title:          string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/olympus-mv-single-step/checkout.html
+++ b/src/olympus-mv-single-step/checkout.html
@@ -3,6 +3,14 @@ title: "Olympus MV Single Checkout"
 page_type: checkout
 next_url: upsell-mv.html
 promo_sale: "default"
+order_bump:
+  check01:
+    title: "Get Extended Warranty"
+    features:
+      - "1 year with our replacement and protection"
+      - "Accidental Damage Protection"
+      - "Express Replacement Service"
+      - "24/7 Priority Customer Support"
 styles:
   - https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css
 scripts:

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,5 +1,8 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+{% assign bump = order_bump.check01 -%}
+{% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign feature_list = features | default: bump.features -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
@@ -23,7 +26,7 @@
           <div class="bump__checkbox">
             <div os-component="check" class="checkbox__icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--fe" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6 10l-2 2l6 6L20 8l-2-2l-8 8z"></path></svg></div>
           </div>
-          <div class="bump__title">Get Extended Warranty</div>
+          <div class="bump__title">{{ t }}</div>
         </div>
       </div>
       <!-- Bump body: price, list, image -->
@@ -48,22 +51,31 @@
             </div>
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">
+                {% if feature_list -%}
+                {% for feat in feature_list -%}
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>{{ feat }}</div>
+                </li>
+                {% endfor -%}
+                {% else -%}
+                <li class="list__item">
+                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>24/7 Priority Customer Support</div>
+                  <div>Order bump feature 4</div>
                 </li>
+                {% endif -%}
               </ul>
             </div>
           </div>

--- a/src/olympus-mv-two-step/_includes/bump-check02.html
+++ b/src/olympus-mv-two-step/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/olympus-mv-two-step/_includes/bump-switch01.html
+++ b/src/olympus-mv-two-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Shipping Insurance & Loss Prevention".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,7 +21,7 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
 {% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">

--- a/src/olympus-mv-two-step/_includes/bump-switch01.html
+++ b/src/olympus-mv-two-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    bump_title:          string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/olympus-mv-two-step/checkout.html
+++ b/src/olympus-mv-two-step/checkout.html
@@ -3,6 +3,14 @@ title: "Olympus MV Two-Step — Checkout"
 page_type: checkout
 next_url: upsell-mv.html
 promo_sale: "default"
+order_bump:
+  check01:
+    title: "Get Extended Warranty"
+    features:
+      - "1 year with our replacement and protection"
+      - "Accidental Damage Protection"
+      - "Express Replacement Service"
+      - "24/7 Priority Customer Support"
 scripts:
   - js/promo-banner.js
   - js/promo-timer.js

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -7,12 +7,12 @@
     packages:             object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package_id and package_sync when not passed explicitly.
     order_bump.check01:   optional frontmatter object for package_id, sync_quantity, title, image_src, image_alt, and features.
     package_id:           number, required. data-next-package-id (the bump's package).
-    bump_title:           string, default "Get Extended Warranty". Bump headline.
+    bump_title:           string, default "Order Bump Title". Bump headline.
     bump_image:           string asset path, default "images/1x1_1.svg". Product imagery.
     bump_image_alt:       string, default "" (matches title when empty).
     package_sync:         number|false, default 1. data-next-package-sync (mirrors main bundle qty). Set to false to disable sync.
     is_upsell:            bool, default true. data-next-is-upsell flag.
-    features:             array of {text} strings, default warranty list. Bullet list shown under price.
+    features:             array of {text} strings, default placeholder list. Bullet list shown under price.
     show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
@@ -44,7 +44,7 @@
 {% endcomment %}
 {% assign bump = order_bump.check01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_1 | default: 7 -%}
-{% assign t = bump_title | default: bump.title | default: 'Get Extended Warranty' -%}
+{% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign img_src = bump_image | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign img_alt = bump_image_alt | default: bump.image_alt | default: t -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign package_sync = packages.main_package | default: 1 %}{% elsif package_sync == nil %}{% assign package_sync = bump.sync_quantity %}{% endif -%}
@@ -103,19 +103,19 @@
                 {% else -%}
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>24/7 Priority Customer Support</div>
+                  <div>Order bump feature 4</div>
                 </li>
                 {%- endif %}
               </ul>

--- a/src/olympus/_includes/bump-check02.html
+++ b/src/olympus/_includes/bump-check02.html
@@ -38,11 +38,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/olympus/_includes/bump-switch01.html
+++ b/src/olympus/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    bump_title:          string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -33,8 +33,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/olympus/_includes/bump-switch01.html
+++ b/src/olympus/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Shipping Insurance & Loss Prevention".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -33,7 +33,7 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
 {% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,5 +1,8 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+{% assign bump = order_bump.check01 -%}
+{% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign feature_list = features | default: bump.features -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
@@ -15,7 +18,7 @@
           <div class="bump__checkbox">
             <div os-component="check" class="checkbox__icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--fe" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6 10l-2 2l6 6L20 8l-2-2l-8 8z"></path></svg></div>
           </div>
-          <div class="bump__title">Get Extended Warranty</div>
+          <div class="bump__title">{{ t }}</div>
         </div>
       </div>
       <!-- Bump body: price, list, image -->
@@ -38,25 +41,33 @@
               </div>
               {% endif %}
             </div>
-            
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">
+                {% if feature_list -%}
+                {% for feat in feature_list -%}
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>{{ feat }}</div>
+                </li>
+                {% endfor -%}
+                {% else -%}
+                <li class="list__item">
+                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>24/7 Priority Customer Support</div>
+                  <div>Order bump feature 4</div>
                 </li>
+                {% endif -%}
               </ul>
             </div>
           </div>

--- a/src/shop-single-step/_includes/bump-check02.html
+++ b/src/shop-single-step/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/shop-single-step/_includes/bump-switch01.html
+++ b/src/shop-single-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Shipping Insurance & Loss Prevention".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,7 +21,7 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
 {% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">

--- a/src/shop-single-step/_includes/bump-switch01.html
+++ b/src/shop-single-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    bump_title:          string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,5 +1,8 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+{% assign bump = order_bump.check01 -%}
+{% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign feature_list = features | default: bump.features -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
@@ -15,7 +18,7 @@
           <div class="bump__checkbox">
             <div os-component="check" class="checkbox__icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--fe" width="100%" height="100%" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6 10l-2 2l6 6L20 8l-2-2l-8 8z"></path></svg></div>
           </div>
-          <div class="bump__title">Get Extended Warranty</div>
+          <div class="bump__title">{{ t }}</div>
         </div>
       </div>
       <!-- Bump body: price, list, image -->
@@ -38,25 +41,33 @@
               </div>
               {% endif %}
             </div>
-            
             <div class="list-container cc-2xs">
               <ul role="list" class="list w-list-unstyled">
+                {% if feature_list -%}
+                {% for feat in feature_list -%}
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>1 year with our replacement and protection</div>
+                  <div>{{ feat }}</div>
+                </li>
+                {% endfor -%}
+                {% else -%}
+                <li class="list__item">
+                  <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
+                  <div>Order bump feature 1</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Accidental Damage Protection</div>
+                  <div>Order bump feature 2</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>Express Replacement Service</div>
+                  <div>Order bump feature 3</div>
                 </li>
                 <li class="list__item">
                   <div class="list_icon"><svg width="100%" height="100%" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" role="presentation" fill="CurrentColor"><path d="M12.265 0.182296C12.0219 -0.0607654 11.6279 -0.0607654 11.3848 0.182296L3.92853 7.63866L1.06245 4.77258C0.819416 4.52952 0.425382 4.52955 0.182296 4.77258C-0.0607654 5.01562 -0.0607654 5.40966 0.182296 5.65272L3.48845 8.95882C3.73142 9.20186 4.12574 9.20169 4.36861 8.95882L12.265 1.06245C12.508 0.819416 12.508 0.425358 12.265 0.182296Z" fill="inherit"></path></svg></div>
-                  <div>24/7 Priority Customer Support</div>
+                  <div>Order bump feature 4</div>
                 </li>
+                {% endif -%}
               </ul>
             </div>
           </div>

--- a/src/shop-three-step/_includes/bump-check02.html
+++ b/src/shop-three-step/_includes/bump-check02.html
@@ -23,11 +23,11 @@
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
 {% if package_sync == nil and bump.sync_quantity == nil %}{% assign sync_qty = packages.main_package | default: 1 %}{% elsif package_sync != nil %}{% assign sync_qty = package_sync %}{% else %}{% assign sync_qty = bump.sync_quantity %}{% endif -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
-{% assign bump_title = bump.title | default: 'YES, &nbsp;I Will Take It' -%}
+{% assign bump_title = bump.title | default: 'Order Bump Title' -%}
 {% assign image_src = bump.image_src | default: 'images/icon.svg' -%}
 {% assign image_alt = bump.image_alt | default: '' -%}
-{% assign description_prefix = bump.description_prefix | default: 'Get peace of mind with' -%}
-{% assign description_suffix = bump.description_suffix | default: 'in the event your delivery is damaged, stolen, or lost during transit for' -%}
+{% assign description_prefix = bump.description_prefix | default: 'Order bump description before price' -%}
+{% assign description_suffix = bump.description_suffix | default: 'order bump description after price' -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check02" data-next-await="">
   <div data-next-package-toggle>
     <div data-next-toggle-card{% if is_upsell %} data-next-is-upsell="true"{% endif %}{% if sync_qty %} data-next-package-sync="{{ sync_qty }}"{% endif %} data-next-package-id="{{ pkg_id }}" class="next-active">

--- a/src/shop-three-step/_includes/bump-switch01.html
+++ b/src/shop-three-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    title:               string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Shipping Insurance & Loss Prevention".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,7 +21,7 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
 {% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">

--- a/src/shop-three-step/_includes/bump-switch01.html
+++ b/src/shop-three-step/_includes/bump-switch01.html
@@ -7,7 +7,7 @@
     packages:            object, optional. Dict with main_package, prepurchase_1, prepurchase_2 keys. Defaults for package IDs when not set explicitly.
     order_bump.switch01: optional frontmatter object for package_id, title, description_prefix, and show_unit_price.
     package_id:          number, default 9.
-    bump_title:          string, default "Shipping Insurance & Loss Prevention".
+    bump_title:          string, default "Order Bump Title".
     description_prefix:  string before the SDK price display.
     show_unit_price:     bool, default true. Shows total + unit price when true.
   next_sdk_owns:
@@ -21,8 +21,8 @@
 {% endcomment %}
 {% assign bump = order_bump.switch01 -%}
 {% assign pkg_id = package_id | default: bump.package_id | default: packages.prepurchase_2 | default: 9 -%}
-{% assign bump_title = bump_title | default: bump.title | default: 'Shipping Insurance & Loss Prevention' -%}
-{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Total shipping coverage and extended warranty. Breakage, loss, delays, porch pirates - even defects. 100% protected for just' -%}
+{% assign bump_title = bump_title | default: bump.title | default: 'Order Bump Title' -%}
+{% assign description_prefix = description_prefix | default: bump.description_prefix | default: 'Order bump description before price' -%}
 {% if show_unit_price == nil and bump.show_unit_price == nil %}{% assign show_unit = true %}{% elsif show_unit_price != nil %}{% assign show_unit = show_unit_price %}{% else %}{% assign show_unit = bump.show_unit_price %}{% endif -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="switch" data-next-await="">
   <div data-next-package-toggle>


### PR DESCRIPTION
Two related changes to the order-bump partials.

## 1. Bug fix — bump-switch01 rendered the page title
`bump-switch01.html` used the bare `title` variable as its first title fallback. Since `campaign_include` runs in page scope, `title` resolved to the frontmatter page title (e.g. "Olympus Checkout") whenever no override was passed. Fixed by switching to a non-colliding `bump_title` arg (the convention `bump-check01` already uses). Affected olympus + mv-pair + shop-pair; demeter/limos were already correct.

## 2. Genericize bump defaults + parameterize mv/shop bump-check01
The bump partials shipped demo-specific warranty/insurance copy as their **defaults**, so a developer copying a template inherited it. Now:

- **Generic placeholder defaults** across all 7 families (`bump-switch01`, `bump-check02`, `bump-check01`): titles → `Order Bump Title`, feature bullets → `Order bump feature N`, descriptions → `Order bump description …`.
- The demo's polished copy now comes **solely from each checkout's `order_bump` frontmatter** (olympus already did this).
- **Parameterized the mv-pair + shop-pair `bump-check01`**, which were previously unparameterized (hardcoded warranty title + feature list). They now read `order_bump.check01` like olympus (`{{ t }}` title, `{% for feat in feature_list %}` with generic fallback), keeping each lineage's distinct sync wiring (MV `data-next-product-sync` / shop `data-next-package-sync`).
- Added `order_bump.check01` (title + features) to the two MV checkout pages so their demo still renders the warranty bump from frontmatter.

## Result
- Developer copies get clean generic defaults.
- Demo polish preserved everywhere (copy lives in frontmatter).
- Build verified: 55 pages, no errors. Demos render warranty copy; `bump-check01` still 4 distinct lineages (D3 catalog #76 unaffected).

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)