### PR TITLE
chore(deps): bump next-campaign-page-kit to ^0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,18 @@ A **complete, working campaign-kit project** that serves two purposes:
 Templates follow SDK **0.4.x** patterns (`olympus`, `limos`, `demeter`, `olympus-mv-single-step`, `olympus-mv-two-step`, `shop-single-step`, `shop-three-step` today).
 
 ## Developer Workflow (end users of this repo)
-1. `npx campaign-init` in their own project → creates empty `_data/campaigns.json` + npm scripts
-2. Copy `src/[slug]/` → their project's `src/[slug]/`
-3. Copy the matching entry from `_data/campaigns.json` into their project's `campaigns.json`, update slug + store URLs
-4. `npm run dev` → interactive campaign picker
-5. To clone a variant: `npm run clone` → picks existing campaign → new slug → auto-updates `campaigns.json`
+As of CPK **0.2.0**, `npx campaign-init` is a full scaffolder. In the developer's own project (which must already have a `package.json` — it warns to run `npm init -y` first), picking a template — via the interactive picker or `--template`/`--slug` flags — it:
+1. Adds the kit npm scripts to `package.json`
+2. Materializes the chosen template into `src/<slug>/` (renamed to the slug)
+3. Seeds `_data/campaigns.json` with a full entry keyed by the slug
+4. Writes the API key into `assets/config.js` when `--api-key` is passed
+5. Optionally installs the AI-context doc with `--ai-context claude|codex|cursor|copilot` (see the rules-file note below)
 
-Note: `npx campaign-init` does NOT create any src/ folders — it only creates `_data/campaigns.json` and adds npm scripts to `package.json`.
+It is conflict-safe: re-running for an existing slug errors unless `--overwrite` is passed. It can run fully non-interactively (`--non-interactive` / `--json`) for agents and CI. After scaffolding: `npm run dev` → interactive campaign picker; `npm run clone` → duplicate a campaign to a new slug.
 
-Note: when copying a template, the developer renames the folder to their product/campaign name (e.g. `wintergloves`), NOT the template name (e.g. `olympus`). The folder name becomes the slug and drives the URL: `campaign-domain.com/wintergloves/checkout`.
+Manual copy (template-library path, when not using the picker/flags): copy `src/[slug]/` into the project and copy the matching `_data/campaigns.json` entry by hand, updating slug + store URLs.
+
+Note: the developer renames the folder to their product/campaign name (e.g. `wintergloves`), NOT the template name (e.g. `olympus`). The folder name becomes the slug and drives the URL: `campaign-domain.com/wintergloves/checkout`.
 
 ---
 
@@ -240,6 +243,6 @@ Design decisions:
 - **Checklists over how-to recipes** — checklists are AI-useful; prose how-tos are not worth the file bloat
 - **`docs/recipes/` was created then deleted** — content absorbed into checklists in the main rules file
 - **Analytics docs not included** — main SDK docs URL is sufficient; AI fetches specific pages when needed
-- **Long-term goal**: wire into `npx campaign-init` so it's auto-delivered to developer projects
+- **Auto-delivery shipped in CPK 0.2.0**: `campaign-init --ai-context claude|codex|cursor|copilot` now installs this doc verbatim into developer projects (with a sentinel header, overwritten on re-run unless `--keep-ai-context`). This file is the upstream source — keeping it correct now directly shapes downstream AI context.
 
 README has an "AI development rules" section pointing developers to copy `docs/campaign-page-kit-template-context.md` into their project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ repo-root/
 ---
 title: "Page Title"
 page_layout: base.html               # optional — defaults to base.html; use named layouts (e.g. base-landing.html) when multiple layout stacks coexist in one slug
-page_type: checkout | upsell | receipt
+page_type: product | checkout | upsell | receipt
 next_url: up01.html          # checkout pages only
 next_url: up02.html        # upsell pages only
 decline_url: receipt.html    # upsell pages only

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -1087,7 +1087,7 @@ If `window.nextDebug` is undefined, debug mode is not enabled — add the meta t
 2. **Use `campaign_link` for all inter-page URLs.** Never hardcode `/slug/page/` paths.
 3. **Only use documented `data-next-*` attributes.** Do not invent attribute names.
 4. **Do not write JavaScript that duplicates SDK behaviour.** The SDK handles cart state, field binding, form submission, upsell accept/decline, and dynamic display. Write JS only for UI behaviour the SDK doesn't cover (e.g. Swiper sliders, modals, custom animations).
-5. **page_type must match the page's role.** `checkout` for payment collection, `upsell` for post-purchase offers, `receipt` for order confirmation. The SDK behaves differently on each.
+5. **page_type must match the page's role.** `product` for presell/landing pages, `checkout` for payment collection, `upsell` for post-purchase offers, `receipt` for order confirmation. The SDK behaves differently on each, and `campaign-build` warns (`INVALID_PAGE_TYPE`) on any other value.
 6. **Keep each campaign self-contained.** Do not reference assets from another campaign's directory.
 7. **`config.js` must load before the SDK.** This is already handled by `base.html` — do not reorder these script tags.
 8. **SDK version is set in campaigns.json**, not in `base.html` directly. To upgrade, update `sdk_version` in the campaign's entry.

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -215,6 +215,21 @@ scripts:
 - `next_url` / `decline_url` are required on upsell pages
 - `styles` / `scripts` are page-specific; `next-core.css` and `config.js` are loaded by `base.html` for every page
 
+### Build validation and warnings (CPK 0.2.0+)
+
+`campaign-build` succeeds even when a page is misconfigured — it emits **non-fatal warnings** to stderr instead of failing. They never change the exit code (the build only exits non-zero on a render error). Run `campaign-build --json` for a per-page summary that attaches each warning to its source file — useful in CI or when an AI agent is checking its own output. Watch for:
+
+| Code | Meaning |
+|------|---------|
+| `INVALID_PAGE_TYPE` | `page_type` is not one of `product`, `checkout`, `upsell`, `receipt` |
+| `MISSING_FRONTMATTER` | `title` or `page_type` is missing (both required) |
+| `LAYOUT_NOT_FOUND` | the `page_layout` name has no file in `src/<slug>/_layouts/` — page rendered with no layout |
+| `NESTED_NO_PERMALINK` | a page in a subdirectory has no `permalink`; routing drops the intermediate dirs (uses only slug + filename) |
+| `DUPLICATE_OUTPUT` | two source files resolve to the same output file; the last one silently wins |
+| `NO_CAMPAIGN` | the page's slug has no `_data/campaigns.json` entry, so it was skipped |
+
+A clean build reports zero warnings — treat any warning as a bug to fix, not noise.
+
 ---
 
 ## Liquid template filters

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "campaign-kit-templates",
       "version": "1.0.0",
       "dependencies": {
-        "next-campaign-page-kit": "^0.1.0"
+        "next-campaign-page-kit": "^0.2.0"
       },
       "devDependencies": {
         "@tailwindcss/cli": "^4.2.4",
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/next-campaign-page-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-campaign-page-kit/-/next-campaign-page-kit-0.1.0.tgz",
-      "integrity": "sha512-e3W6JW8BRiFEbMc81e2yDwIB/KZEP1WhzDz33HwT05sX+4UEAMXsMLE05158qIlQvgu3lVBe9dVB6fRrWhExaQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/next-campaign-page-kit/-/next-campaign-page-kit-0.2.0.tgz",
+      "integrity": "sha512-5fdRUSe3Hd6j5zt/6mJyEFogNpTV3BSp/iy/tKL6mdwiWfAz73ghmvpPzVRom8dtPrfk+B3GQaLeJw2tTA7M1Q==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:agent-contracts": "node scripts/lint-agent-contracts.mjs"
   },
   "dependencies": {
-    "next-campaign-page-kit": "^0.1.0"
+    "next-campaign-page-kit": "^0.2.0"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.2.4",


### PR DESCRIPTION
## Summary

Adopts **next-campaign-page-kit 0.2.0** (was `^0.1.0`). This repo is the built-in `public` template source CPK pulls from, so the bump was validated against the new 0.2.0 build validator.

### What's new in CPK 0.2.0
- **Pluggable template sources** — `public` (built-in) plus developer-added `local`/`git` (SSH) sources via `_data/template-sources.json`
- **Non-interactive `campaign-init`** — `--non-interactive` / `--json` with full flag set and documented exit codes
- **AI-context install** — `--ai-context <claude|codex|cursor|copilot>` installs `docs/campaign-page-kit-template-context.md` into developer projects
- **`campaign-build --json`** — structured per-page build summary + non-fatal build warnings (`INVALID_PAGE_TYPE`, `MISSING_FRONTMATTER`, `LAYOUT_NOT_FOUND`, etc.)

### Changes in this PR
- `package.json` + `package-lock.json` — `^0.1.0` → `^0.2.0`
- `CLAUDE.md` — add `product` to the `page_type` frontmatter line
- `docs/campaign-page-kit-template-context.md` — rule #5 now documents `product` (presell/landing) and references the new `INVALID_PAGE_TYPE` warning

### Validation
`npm run build` against 0.2.0 → **55 pages, 0 errors, 0 warnings, 0 skipped** (confirmed via `campaign-build --json`). `templates.json` already matches the new catalog schema; no `_data/template-sources.json` needed (`public` is built in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)