### PR TITLE
Gate starter bump compare price rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ Demeter pricing surfaces render price rows from a `pricing_mode` partial argumen
 - Surfaces + partial defaults (per contract): upsell offers (`upsell-bundle-stepper-offer.html`, `upsell-bundle-tier-pills-offer.html`, `upsell-bundle-tier-cards-offer.html`) default **full_price** — exactly one visible price row adjacent to the accept control; `bump-check01.html` defaults **full_price** (one `unitPrice`/ea row); `editorial-tier-selector.html` defaults **discounted** (current compare-unit-total render), with per-card override via `bundles[].pricing_mode`.
 - Pass the mode as an include arg (`pricing_mode='discounted'`) or via `upsell_offer.pricing_mode` / `order_bump.check01.pricing_mode` frontmatter; include arg wins. Visible-row counts on upsells: full_price/unit_only = 1, discounted/compare_at/unit_total = 2.
 - Demo pages opt into `discounted` explicitly to keep the showcase visuals; legacy `show_per_unit_price`/`show_line_total_price` (bump) and `price_display_variant` (tier selector) still work when passed explicitly without `pricing_mode`.
+- `bump-check01.html` also accepts legacy `show_compare_price=false` by default. Leave demo pages unset so non-discounted bump previews show one sale price; pass `show_compare_price=true` only when the campaign intentionally wants the struck `originalUnitPrice` before SDK `hasDiscount` is true.
 
 Inside `<template>` elements the SDK uses single-brace tokens (not Liquid):
 ```html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Demeter pricing surfaces render price rows from a `pricing_mode` partial argumen
 - Surfaces + partial defaults (per contract): upsell offers (`upsell-bundle-stepper-offer.html`, `upsell-bundle-tier-pills-offer.html`, `upsell-bundle-tier-cards-offer.html`) default **full_price** — exactly one visible price row adjacent to the accept control; `bump-check01.html` defaults **full_price** (one `unitPrice`/ea row); `editorial-tier-selector.html` defaults **discounted** (current compare-unit-total render), with per-card override via `bundles[].pricing_mode`.
 - Pass the mode as an include arg (`pricing_mode='discounted'`) or via `upsell_offer.pricing_mode` / `order_bump.check01.pricing_mode` frontmatter; include arg wins. Visible-row counts on upsells: full_price/unit_only = 1, discounted/compare_at/unit_total = 2.
 - Demo pages opt into `discounted` explicitly to keep the showcase visuals; legacy `show_per_unit_price`/`show_line_total_price` (bump) and `price_display_variant` (tier selector) still work when passed explicitly without `pricing_mode`.
-- `bump-check01.html` also accepts legacy `show_compare_price=false` by default. Leave demo pages unset so non-discounted bump previews show one sale price; pass `show_compare_price=true` only when the campaign intentionally wants the struck `originalUnitPrice` before SDK `hasDiscount` is true.
+- `bump-check01.html` also accepts legacy `show_compare_price=false` by default. Leave demo pages unset so bump previews show one sale price; pass `show_compare_price=true` only when the campaign intentionally wants the struck `originalUnitPrice`.
 
 Inside `<template>` elements the SDK uses single-brace tokens (not Liquid):
 ```html

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Every checkout template includes `presell.html` and `landing.html` — a full pr
 | `[any slug]` · landing | Composable landing page | [olympus example](https://nextcommerce-campaign-templates.netlify.app/olympus/landing/) |
 | `landing` | Full section showcase (every component) | [preview](https://nextcommerce-campaign-templates.netlify.app/landing/index/) |
 
+## Migration notes
+
+Starter `bump-check01.html` order bumps now default to a single visible sale price row. Existing cloned campaigns that want the struck `originalUnitPrice` row should pass `show_compare_price=true`; leave it unset when the bump should render only the current `unitPrice`/ea price.
+
 ## npm scripts
 
 Run these inside the repository root:

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -636,10 +636,14 @@ Key token semantics (0.4.11+): `{item.price}` / `{item.originalPrice}` = **line 
 </div>
 ```
 
+#### Order-bump pricing args
+
 Starter `bump-check01.html` partials expose three pricing args:
 - `show_per_unit_price` defaults to `true` and renders the stable `unitPrice`/ea row.
 - `show_line_total_price` defaults to `false` and opts into the line-total `originalPrice + price` row.
 - `show_compare_price` defaults to `false`; set it to `true` only when the campaign deliberately wants a struck `originalUnitPrice` visible. The starter demos intentionally do not pass it, so bump previews show a single sale price.
+
+Migration note for existing cloned campaigns: starter bumps now default to a single visible sale price row. Pass `show_compare_price=true` to restore the struck `originalUnitPrice` row for bumps that should visibly compare against a prior price.
 
 CSS required for checkbox state (already in `next-core.css` — only add if using a custom stylesheet):
 ```css

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -636,6 +636,11 @@ Key token semantics (0.4.11+): `{item.price}` / `{item.originalPrice}` = **line 
 </div>
 ```
 
+Starter `bump-check01.html` partials expose three pricing args:
+- `show_per_unit_price` defaults to `true` and renders the stable `unitPrice`/ea row.
+- `show_line_total_price` defaults to `false` and opts into the line-total `originalPrice + price` row.
+- `show_compare_price` defaults to `false`; set it to `true` only when the campaign deliberately wants a struck `originalUnitPrice` visible even before the SDK reports `hasDiscount`. The starter demos intentionally do not pass it, so non-discounted bump previews show a single sale price.
+
 CSS required for checkbox state (already in `next-core.css` — only add if using a custom stylesheet):
 ```css
 [data-next-bump] [os-component="check"] { display: none; }

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -639,7 +639,7 @@ Key token semantics (0.4.11+): `{item.price}` / `{item.originalPrice}` = **line 
 Starter `bump-check01.html` partials expose three pricing args:
 - `show_per_unit_price` defaults to `true` and renders the stable `unitPrice`/ea row.
 - `show_line_total_price` defaults to `false` and opts into the line-total `originalPrice + price` row.
-- `show_compare_price` defaults to `false`; set it to `true` only when the campaign deliberately wants a struck `originalUnitPrice` visible even before the SDK reports `hasDiscount`. The starter demos intentionally do not pass it, so non-discounted bump previews show a single sale price.
+- `show_compare_price` defaults to `false`; set it to `true` only when the campaign deliberately wants a struck `originalUnitPrice` visible. The starter demos intentionally do not pass it, so bump previews show a single sale price.
 
 CSS required for checkbox state (already in `next-core.css` — only add if using a custom stylesheet):
 ```css

--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -22,7 +22,7 @@
                         unit_total = unitPrice/ea + line total (scales with synced qty).
                         Pick the mode here — campaign CSS must never display:none price rows.
     show_compare_price:   bool, LEGACY. Explicitly include the struck originalUnitPrice in Option A.
-    show_per_unit_price:  bool, LEGACY. Render Option A row (unitPrice/ea, plus originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
+    show_per_unit_price:  bool, LEGACY. Render Option A row (unitPrice/ea, plus originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, LEGACY. Render Option B row (originalPrice + price). Only honored when
                         pricing_mode is not set and at least one legacy bool is passed explicitly.
   next_sdk_owns:
@@ -61,7 +61,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pricing rows are pricing_mode-driven (default full_price = one visible unitPrice/ea row).
      Legacy show_per_unit_price / show_line_total_price still work when passed explicitly without pricing_mode:
-     Option A (per-unit, stable): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount
+     Option A (per-unit, stable): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true
      Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
@@ -84,7 +84,7 @@
               {% if show_per_unit_price %}
               <!-- Legacy Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -21,7 +21,8 @@
                         original is always shown either way (compare_at semantics);
                         unit_total = unitPrice/ea + line total (scales with synced qty).
                         Pick the mode here — campaign CSS must never display:none price rows.
-    show_per_unit_price:  bool, LEGACY. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_compare_price:   bool, LEGACY. Explicitly include the struck originalUnitPrice in Option A.
+    show_per_unit_price:  bool, LEGACY. Render Option A row (unitPrice/ea, plus originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, LEGACY. Render Option B row (originalPrice + price). Only honored when
                         pricing_mode is not set and at least one legacy bool is passed explicitly.
   next_sdk_owns:
@@ -56,10 +57,11 @@
 {% endif -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pricing rows are pricing_mode-driven (default full_price = one visible unitPrice/ea row).
      Legacy show_per_unit_price / show_line_total_price still work when passed explicitly without pricing_mode:
-     Option A (per-unit, stable): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true
      Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
@@ -82,7 +84,9 @@
               {% if show_per_unit_price %}
               <!-- Legacy Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
+                {% if show_compare_price %}
                 <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/demeter/_includes/bump-check01.html
+++ b/src/demeter/_includes/bump-check01.html
@@ -22,7 +22,7 @@
                         unit_total = unitPrice/ea + line total (scales with synced qty).
                         Pick the mode here — campaign CSS must never display:none price rows.
     show_compare_price:   bool, LEGACY. Explicitly include the struck originalUnitPrice in Option A.
-    show_per_unit_price:  bool, LEGACY. Render Option A row (unitPrice/ea, plus originalUnitPrice/ea only when show_compare_price=true).
+    show_per_unit_price:  bool, LEGACY. Render Option A row (unitPrice/ea, plus originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
     show_line_total_price:bool, LEGACY. Render Option B row (originalPrice + price). Only honored when
                         pricing_mode is not set and at least one legacy bool is passed explicitly.
   next_sdk_owns:
@@ -61,7 +61,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pricing rows are pricing_mode-driven (default full_price = one visible unitPrice/ea row).
      Legacy show_per_unit_price / show_line_total_price still work when passed explicitly without pricing_mode:
-     Option A (per-unit, stable): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true
+     Option A (per-unit, stable): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount
      Option B (line total, scales): originalPrice + price — multiplies with data-next-package-sync qty -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
@@ -84,9 +84,7 @@
               {% if show_per_unit_price %}
               <!-- Legacy Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
-                {% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/limos/_includes/bump-check01.html
+++ b/src/limos/_includes/bump-check01.html
@@ -11,8 +11,8 @@
     title:              string, default "Order Bump Title".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
-    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
-    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -37,7 +37,7 @@
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -60,7 +60,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/limos/_includes/bump-check01.html
+++ b/src/limos/_includes/bump-check01.html
@@ -11,7 +11,7 @@
     title:              string, default "Order Bump Title".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
-    show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -32,10 +32,11 @@
 {% assign bump_image = image_src | default: bump.image_src | default: 'images/1x1_1.svg' -%}
 {% assign feature_list = features | default: bump.features -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -58,7 +59,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/limos/_includes/bump-check01.html
+++ b/src/limos/_includes/bump-check01.html
@@ -11,7 +11,8 @@
     title:              string, default "Order Bump Title".
     image_src:          string asset path, default "images/1x1_1.svg".
     features:           array of bullet strings.
-    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -36,7 +37,7 @@
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -59,7 +60,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,3 +1,10 @@
+{% comment %}
+  next_component: order-bump-card
+  next_params:
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
+    show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
+{% endcomment %}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
@@ -7,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -38,7 +45,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
-    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
@@ -14,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -45,7 +45,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,4 +1,5 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 {% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
@@ -6,7 +7,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -37,7 +38,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,3 +1,10 @@
+{% comment %}
+  next_component: order-bump-card
+  next_params:
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
+    show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
+{% endcomment %}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
@@ -7,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -38,7 +45,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
-    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
@@ -14,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -45,7 +45,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,4 +1,5 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 {% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
@@ -6,7 +7,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -37,7 +38,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -13,7 +13,8 @@
     package_sync:         number|false, default 1. data-next-package-sync (mirrors main bundle qty). Set to false to disable sync.
     is_upsell:            bool, default true. data-next-is-upsell flag.
     features:             array of {text} strings, default placeholder list. Bullet list shown under price.
-    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
+    show_compare_price:   bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -56,7 +57,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -79,7 +80,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -22,7 +22,6 @@
     - data-next-toggle-display
     - data-next-package-sync (mirrors main bundle quantity)
     - data-next-await
-    - data-next-bundle-display (originalUnitPrice, unitPrice, originalPrice, price, hasDiscount)
   next_theming:
     classes_designer_owns: [.toggle-card, .toggle-card__*, .checkbox-style-1, .pb--bestseller, .bump-card, .bump__title, .bump__price, .bump__price-row, .bump__image, .list-container]
     css_vars_designer_owns: []

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -13,8 +13,8 @@
     package_sync:         number|false, default 1. data-next-package-sync (mirrors main bundle qty). Set to false to disable sync.
     is_upsell:            bool, default true. data-next-is-upsell flag.
     features:             array of {text} strings, default placeholder list. Bullet list shown under price.
-    show_compare_price:   bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
-    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount).
+    show_compare_price:   bool, default false. Explicitly render struck originalUnitPrice in Option A.
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -57,7 +57,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -80,7 +80,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/olympus/_includes/bump-check01.html
+++ b/src/olympus/_includes/bump-check01.html
@@ -13,7 +13,7 @@
     package_sync:         number|false, default 1. data-next-package-sync (mirrors main bundle qty). Set to false to disable sync.
     is_upsell:            bool, default true. data-next-is-upsell flag.
     features:             array of {text} strings, default placeholder list. Bullet list shown under price.
-    show_per_unit_price:  bool, default true. Render Option A row (originalUnitPrice/ea + unitPrice/ea).
+    show_per_unit_price:  bool, default true. Render Option A row (unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true).
     show_line_total_price:bool, default false. Render Option B row (originalPrice + price). Pick A or B, not both — defaults to A (per-unit) because it's stable across tier changes.
   next_sdk_owns:
     - data-next-package-toggle
@@ -51,11 +51,12 @@
 {% assign feature_list = features | default: bump.features -%}
 {% if is_upsell == nil %}{% assign is_upsell = true %}{% endif -%}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -78,7 +79,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,3 +1,10 @@
+{% comment %}
+  next_component: order-bump-card
+  next_params:
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
+    show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
+{% endcomment %}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
@@ -7,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -30,7 +37,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,4 +1,5 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 {% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
@@ -6,7 +7,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -29,7 +30,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
-    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
@@ -14,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -37,7 +37,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,3 +1,10 @@
+{% comment %}
+  next_component: order-bump-card
+  next_params:
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
+    show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
+{% endcomment %}
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
 {% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
@@ -7,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -30,7 +37,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,4 +1,5 @@
 {% if show_per_unit_price == nil %}{% assign show_per_unit_price = true %}{% endif -%}
+{% if show_compare_price == nil %}{% assign show_compare_price = false %}{% endif -%}
 {% if show_line_total_price == nil %}{% assign show_line_total_price = false %}{% endif -%}
 {% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
@@ -6,7 +7,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -29,7 +30,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                <div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
-    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A; otherwise SDK hasDiscount gates it.
+    show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
@@ -14,7 +14,7 @@
 <!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
-     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true or SDK hasDiscount — does not scale with synced qty
+     Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
 <div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
@@ -37,7 +37,7 @@
               {% if show_per_unit_price %}
               <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
               <div class="bump__price-row">
-                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% else %}<div data-next-bundle-display="hasDiscount" class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
+                {% if show_compare_price %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}


### PR DESCRIPTION
Summary
- default bump compare-price rendering to off across public starter templates
- keep struck originalUnitPrice available only when show_compare_price=true
- preserve Demeter explicit discounted/compare_at pricing modes

Validation
- npm run lint:sdk:ci
- npm run lint:sdk:promoted:source && npm run lint:agent-contracts
- git diff --check