### PR TITLE
fix(order-bump): wrap bump-check01 in data-next-catalog-component

### DIFF
--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -9,7 +9,7 @@
      Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
-<div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
+<div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
          data-next-package-sync matches cart lines by packageId, which under-counts on a configurable

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -9,7 +9,7 @@
      Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
-<div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
+<div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
          data-next-package-sync matches cart lines by packageId, which under-counts on a configurable

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -9,7 +9,7 @@
      Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
-<div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
+<div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
       <!-- Bump header — visual only, whole card is the toggle target -->

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -9,7 +9,7 @@
      Option A (per-unit, stable, DEFAULT): originalUnitPrice/ea + unitPrice/ea — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
        To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
-<div data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
+<div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
     <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
       <!-- Bump header — visual only, whole card is the toggle target -->


### PR DESCRIPTION
## What
The `bump-check01` partial's top-level wrapper was missing `data-next-catalog-component`, so its SDK attributes (`data-next-package-toggle`, `data-next-toggle-card`, `data-next-bundle-id`, `data-next-bundle-items`) rendered **outside** a catalog wrapper.

`npm run lint:sdk:ci` (the `--scope=all --pages=all` rendered check) flagged **4 violations** on the olympus-mv checkout pages, where the bump is actually rendered:
- `olympus-mv-single-step/checkout` — `data-next-package-toggle`, `data-next-toggle-card`
- `olympus-mv-two-step/checkout` — `data-next-package-toggle`, `data-next-toggle-card`

## Fix
Add `data-next-catalog-component="order-bump-card"` to the wrapper `<div>` in all four partials that lacked it, matching the **canonical pattern already used by `demeter`, `limos`, and `olympus`**:
- `src/olympus-mv-single-step/_includes/bump-check01.html` ← resolves the active violations
- `src/olympus-mv-two-step/_includes/bump-check01.html` ← resolves the active violations
- `src/shop-single-step/_includes/bump-check01.html` ← same latent gap (dormant: shop renders `bump-check02` by default)
- `src/shop-three-step/_includes/bump-check01.html` ← same latent gap

One attribute added per file; no markup-structure change. Bringing the shop copies in line prevents the identical violation from surfacing the moment a shop campaign switches to `check01`.

## Verification
- `npm run build` — green (55 pages)
- `npm run lint:sdk:ci` — **PASS** (was FAIL with 4 violations)
- `npm run lint:agent-contracts` — PASS
- Confirmed the rendered olympus-mv checkout pages now wrap the bump in `data-next-catalog-component="order-bump-card"`.

Separate from #86 (variant-picker); this is the follow-up flagged in that PR's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)