### PR TITLE
fix(olympus): tokenize pill label colors + add order-bumps spacing

### DIFF
--- a/src/olympus/assets/css/next-core.css
+++ b/src/olympus/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {
@@ -12380,6 +12388,15 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
+
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
 
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);

--- a/src/olympus/checkout.html
+++ b/src/olympus/checkout.html
@@ -328,6 +328,7 @@ bundles:
                             </div>
                         {% assign bump_variant = order_bump_variant | default: 'check01+switch01' %}
                         {% unless bump_variant == 'none' %}
+                          <div class="order-bumps">
                           {% if bump_variant == 'check01' %}
                           {% campaign_include 'bump-check01.html' packages=packages %}
                           {% elsif bump_variant == 'check02' %}
@@ -341,6 +342,7 @@ bundles:
                           {% campaign_include 'bump-check01.html' packages=packages %}
                           {% campaign_include 'bump-switch01.html' packages=packages %}
                           {% endif %}
+                          </div>
                         {% endunless %}
                             <div class="form-section form-section--last">
                               <div class="form-section__header">


### PR DESCRIPTION
Two next-core template fixes for the `olympus` family, paired with the Chamelo Shield build remediation (`campaigns-os-shield-build-learnings.md` A3/B2). Companion to draft PR NextCommerceCo/campaigns-os#117.

## 1. Tokenize pill label colors (A3/B2: hardcoded values unoverridable by brand layer)
`.os-card__label--pill-primary` / `--pill-secondary` ("Most Popular" / "Best Deal" badges) used **hardcoded hex** in `next-core.css`, so the generated `brand-theme.css` layer could not override them — off-brand colors bleed through on every cloned campaign.

- Added `--brand--color--pill-primary` / `-surface` and `--pill-secondary` / `-surface` tokens (seeded with the existing green/blue values, so **no visual change** to the demo).
- Pill rules now reference the tokens → the brand layer governs them.

> ⚠️ **Heads-up on the brief:** the task named a hardcoded `#C670FE` purple. That hex is **not present anywhere** in this `olympus` template, the whole repo, or its full git history — `git blame` shows the pills have been green (`#08927a`/`#ecfbcb`) and blue (`#298fbd`/`#e4f7ff`) since Apr 2026. The named purple was likely from a different/older snapshot or the generated brand layer at Shield-build time. The *underlying class of bug* (pill colors hardcoded in `next-core.css`) is identical, so I tokenized the green/blue literals that are actually there.

## 2. Order-bumps spacing
Each bump include renders as its own `[data-component="prepurchase-upsell"]` block, and `.form-content` has no `gap`, so consecutive bumps sat **flush**. Wrapped the bump includes in a new `.order-bumps` container (`checkout.html`) and added a base `.order-bumps` rule (flex column, `gap: 1rem`, `margin: 1rem 0`).

## Verification
`npx campaign-build` (55 pages, clean) + browser check of `/olympus/checkout/`:
- Pills resolve through the tokens (`rgb(8,146,122)` / `rgb(41,143,189)`) and **repaint when the token is overridden at `:root`** (confirmed the brand layer can now govern them).
- Order bumps render with a measured **16px gap** between cards (was 0).

## Follow-up (not in this PR)
Per decision, **skipped** the `forbidden_computed_colors` contract entry for `#C670FE` — there is no purple to forbid in this template, so the guard would be a no-op. The still-relevant note for campaigns-os#117: pill colors are now tokenized; if a residual-purple guard is wanted, target the post-tokenization default hexes rather than `#C670FE`.

> Note: `next-core.css` is normally synced across template families; this change is `olympus`-only per the task scope. A follow-up can propagate the pill tokens + `.order-bumps` rule to the other families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)