### PR TITLE
fix(templates): propagate pill-color tokens + bump spacing to remaining families

### DIFF
--- a/src/demeter/assets/css/next-core.css
+++ b/src/demeter/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {
@@ -12402,6 +12410,19 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
+
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
+.order-bumps:empty {
+  display: none;
+}
 
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);

--- a/src/demeter/assets/css/next-core.css
+++ b/src/demeter/assets/css/next-core.css
@@ -12420,10 +12420,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   display: flex;
 }
 
-.order-bumps:empty {
-  display: none;
-}
-
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/demeter/checkout.html
+++ b/src/demeter/checkout.html
@@ -244,18 +244,19 @@ scripts:
                                 <!-- DEMO-ONLY override: pricing_mode='discounted' keeps the showcase's struck-price look.
                                      The contract default for bumps is full_price (single unitPrice/ea row) — when cloning
                                      this page for a real campaign, drop the arg unless the bump has a genuine discount. -->
+                                {% unless bump_variant == 'none' or bump_variant == 'off' or bump_variant == 'false' %}
                                 <div class="order-bumps">
                                 {% case bump_variant %}
                                 {% when 'check01' %}
                                 {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
                                 {% when 'switch01' %}
                                 {% campaign_include 'bump-switch01.html' packages=packages %}
-                                {% when 'none', 'off', 'false' %}
                                 {% else %}
                                 {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
                                 {% campaign_include 'bump-switch01.html' packages=packages %}
                                 {% endcase %}
                                 </div>
+                                {% endunless %}
                                 <div class="form-section form-section--last">
                                   <div class="form-section__header">
                                     <h1 class="form-section__title">Payment</h1>

--- a/src/demeter/checkout.html
+++ b/src/demeter/checkout.html
@@ -244,6 +244,7 @@ scripts:
                                 <!-- DEMO-ONLY override: pricing_mode='discounted' keeps the showcase's struck-price look.
                                      The contract default for bumps is full_price (single unitPrice/ea row) — when cloning
                                      this page for a real campaign, drop the arg unless the bump has a genuine discount. -->
+                                <div class="order-bumps">
                                 {% case bump_variant %}
                                 {% when 'check01' %}
                                 {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
@@ -254,6 +255,7 @@ scripts:
                                 {% campaign_include 'bump-check01.html' packages=packages pricing_mode='discounted' %}
                                 {% campaign_include 'bump-switch01.html' packages=packages %}
                                 {% endcase %}
+                                </div>
                                 <div class="form-section form-section--last">
                                   <div class="form-section__header">
                                     <h1 class="form-section__title">Payment</h1>

--- a/src/limos/assets/css/next-core.css
+++ b/src/limos/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {
@@ -12402,6 +12410,19 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
+
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
+.order-bumps:empty {
+  display: none;
+}
 
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);

--- a/src/limos/assets/css/next-core.css
+++ b/src/limos/assets/css/next-core.css
@@ -12420,10 +12420,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   display: flex;
 }
 
-.order-bumps:empty {
-  display: none;
-}
-
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/limos/checkout.html
+++ b/src/limos/checkout.html
@@ -258,18 +258,19 @@ scripts:
                           {% campaign_include 'payment-methods.html' show_paypal=true show_klarna=true show_apple_pay=true show_google_pay=true %}
                         </div>
                         {% assign bump_variant = order_bump_variant | default: 'check01+switch01' %}
+                        {% unless bump_variant == 'none' or bump_variant == 'off' or bump_variant == 'false' %}
                         <div class="order-bumps">
                         {% case bump_variant %}
                         {% when 'check01' %}
                         {% campaign_include 'bump-check01.html' packages=packages %}
                         {% when 'switch01' %}
                         {% campaign_include 'bump-switch01.html' packages=packages %}
-                        {% when 'none', 'off', 'false' %}
                         {% else %}
                         {% campaign_include 'bump-check01.html' packages=packages %}
                         {% campaign_include 'bump-switch01.html' packages=packages %}
                         {% endcase %}
                         </div>
+                        {% endunless %}
                         <div class="submit-section submit-section--no-margin-top">
                           <div class="submit-section__button">
                             <button os-checkout-payment="combo" data-action="submit" type="submit" class="submit-button submit-button--compact">

--- a/src/limos/checkout.html
+++ b/src/limos/checkout.html
@@ -258,6 +258,7 @@ scripts:
                           {% campaign_include 'payment-methods.html' show_paypal=true show_klarna=true show_apple_pay=true show_google_pay=true %}
                         </div>
                         {% assign bump_variant = order_bump_variant | default: 'check01+switch01' %}
+                        <div class="order-bumps">
                         {% case bump_variant %}
                         {% when 'check01' %}
                         {% campaign_include 'bump-check01.html' packages=packages %}
@@ -268,6 +269,7 @@ scripts:
                         {% campaign_include 'bump-check01.html' packages=packages %}
                         {% campaign_include 'bump-switch01.html' packages=packages %}
                         {% endcase %}
+                        </div>
                         <div class="submit-section submit-section--no-margin-top">
                           <div class="submit-section__button">
                             <button os-checkout-payment="combo" data-action="submit" type="submit" class="submit-button submit-button--compact">

--- a/src/olympus-mv-single-step/assets/css/next-core.css
+++ b/src/olympus-mv-single-step/assets/css/next-core.css
@@ -12411,6 +12411,15 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
 
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/olympus-mv-single-step/assets/css/next-core.css
+++ b/src/olympus-mv-single-step/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {

--- a/src/olympus-mv-two-step/assets/css/next-core.css
+++ b/src/olympus-mv-two-step/assets/css/next-core.css
@@ -12411,6 +12411,15 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
 
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/olympus-mv-two-step/assets/css/next-core.css
+++ b/src/olympus-mv-two-step/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {

--- a/src/shop-single-step/assets/css/next-core.css
+++ b/src/shop-single-step/assets/css/next-core.css
@@ -12411,6 +12411,15 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
 
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/shop-single-step/assets/css/next-core.css
+++ b/src/shop-single-step/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {

--- a/src/shop-three-step/assets/css/next-core.css
+++ b/src/shop-three-step/assets/css/next-core.css
@@ -12411,6 +12411,15 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 /* ========== Prepurchase upsell (checkout add-on blocks) ========== */
 /* Isolated from upsell-page styles so checkout and upsell templates don’t share class names. */
 
+/* Order-bumps container: stacks one or more prepurchase-upsell components.
+   .form-content has no gap, so without this the bump cards render flush. */
+.order-bumps {
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+  display: flex;
+}
+
 [data-component="prepurchase-upsell"] {
   border: 2px dashed var(--brand--color--primary-dark);
   border-radius: var(--radius--cards);

--- a/src/shop-three-step/assets/css/next-core.css
+++ b/src/shop-three-step/assets/css/next-core.css
@@ -68,6 +68,14 @@
   --brand--color--text-inverse: white;
   --brand--color--rating-star: var(--brand--color--primary-dark);
 
+  /* Brand – badge / pill labels (.os-card__label--pill-*). Tokenized so the
+     generated brand-theme layer can override them; do not hardcode hex on the
+     pill rules. */
+  --brand--color--pill-primary: #08927a;
+  --brand--color--pill-primary-surface: #ecfbcb;
+  --brand--color--pill-secondary: #298fbd;
+  --brand--color--pill-secondary-surface: #e4f7ff;
+
   /* Neutrals */
   --neutral--25: #fcfcfd;
   --neutral--100: #f2f4f7;
@@ -6875,13 +6883,13 @@ figcaption {
 }
 
 .os-card__label-2.os-card__label--pill-primary {
-  color: #08927a;
-  background-color: #ecfbcb;
+  color: var(--brand--color--pill-primary);
+  background-color: var(--brand--color--pill-primary-surface);
 }
 
 .os-card__label-2.os-card__label--pill-secondary {
-  color: #298fbd;
-  background-color: #e4f7ff;
+  color: var(--brand--color--pill-secondary);
+  background-color: var(--brand--color--pill-secondary-surface);
 }
 
 .card-sup {


### PR DESCRIPTION
Follow-up to [#88](https://github.com/NextCommerceCo/campaign-cart-starter-templates/pull/88) (which fixed `olympus`). Propagates the same two `next-core` fixes to the other template families.

## Pill-color tokenization — all six families
`demeter`, `limos`, `shop-single-step`, `shop-three-step`, `olympus-mv-single-step`, `olympus-mv-two-step`.

The `.os-card__label--pill-primary` / `--pill-secondary` badge colors were **hardcoded hex** (`#08927a`/`#ecfbcb`, `#298fbd`/`#e4f7ff`) in `next-core.css`, so the generated `brand-theme.css` layer could not override them. Moved to `--brand--color--pill-primary[-surface]` / `--pill-secondary[-surface]` tokens; the pill rules now reference the tokens. **Pure refactor — no visual change** (tokens seeded with the existing values).

## Order-bumps spacing
The `.order-bumps` container rule (flex column, `gap: 1rem`, `margin: 1rem 0`) is added to **all six families' `next-core.css`**, keeping the base stylesheet uniform across the whole template set — stacking multiple bumps back-to-back is a UI design choice any template should support, so the styling hook exists everywhere rather than only where the demo currently wires two bumps.

The checkout markup wrapper (`<div class="order-bumps">` around the bump includes) is added only to **`demeter` + `limos`**, the two families that render two bumps back-to-back (`check01` + `switch01`) and so hit the flush-stacking bug. The wrapper sits inside an `{% unless bump_variant == 'none' or 'off' or 'false' %}` guard, so a disabled bump renders no empty container — no `:empty` CSS fallback is needed.

The four single-bump families (`shop-single-step`, `shop-three-step`, `olympus-mv-single-step`, `olympus-mv-two-step`) render exactly one bump today, so they get the CSS rule (for uniformity + future multi-bump use) but no markup wrapper.

## Verification
`npx campaign-build` (57 pages, clean) + browser check:
- `demeter` & `limos` `/checkout/` render `.order-bumps` with **2 bumps at a measured 16px gap** (was 0).
- Pill tokens resolve (`rgb(8,146,122)` / `rgb(41,143,189)`) and **repaint when overridden at `:root`** — confirmed on `olympus-mv-single-step/checkout` (green → red), proving the brand layer now governs them across all families.

> Note: `next-core.css` is now uniform across all families for both the pill tokens and the `.order-bumps` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
