### PR TITLE
ci: gate SDK-markup linter (lint:sdk:ci) on PRs

### DIFF
--- a/.github/workflows/lint-sdk.yml
+++ b/.github/workflows/lint-sdk.yml
@@ -1,0 +1,31 @@
+name: lint:sdk
+
+# SDK-markup discipline gate. Builds all template families and runs the catalog
+# linter (lint:sdk:ci = lint-sdk.mjs --scope=all --pages=all) in both source and
+# rendered modes, so SDK-binding drift across any family fails the PR instead of
+# slipping in silently. Make this a required status check in branch protection.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build all template families
+        run: npm run build
+      - name: Lint SDK markup (all families, source + rendered)
+        run: npm run lint:sdk:ci


### PR DESCRIPTION
## What

Adds `.github/workflows/lint-sdk.yml` — a CI workflow that builds all template families and runs `npm run lint:sdk:ci` on every PR and on push to `main`.

## Why

`lint:sdk:ci` (`lint-sdk.mjs --scope=all --pages=all`) already:
- covers **all 8 template families** (`--scope=all` scans `src/` dynamically — olympus, limos, demeter, the two olympus-mv families, both shop families, landing), not just the v0 olympus+checkout scope;
- runs **both source and rendered modes** (catches inlined SDK roots in page templates *and* rendered SDK attributes outside catalog wrappers); and
- exits non-zero on violations.

But nothing ran it in CI — it was build-time/manual only, so SDK-binding drift could merge unnoticed. This wires it as a gate. Verified green on current `main` locally (`build` → 57 pages, `lint:sdk:ci` → PASS).

## Follow-up (not in this PR)

Make **lint-sdk** a required status check in branch protection so the gate is enforced, not just advisory.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)