### PR TITLE
ci: next-core.css sync gate + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot keeps this repo aligned with upstream releases by opening PRs when a
+# newer version ships. Each PR runs through the lint-sdk gate (next-core sync +
+# build + SDK lint), so a bump that breaks anything fails its own PR. Nothing
+# auto-merges — review the green ones and merge.
+version: 2
+updates:
+  # npm — most importantly next-campaign-page-kit (the build tool / SDK pin).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Collapse routine minor/patch bumps into one PR to cut noise; majors
+      # still open individually so breaking changes get their own review.
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions used by .github/workflows/*.yml (checkout, setup-node, …).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/lint-sdk.yml
+++ b/.github/workflows/lint-sdk.yml
@@ -1,9 +1,13 @@
 name: lint:sdk
 
-# SDK-markup discipline gate. Builds all template families and runs the catalog
-# linter (lint:sdk:ci = lint-sdk.mjs --scope=all --pages=all) in both source and
-# rendered modes, so SDK-binding drift across any family fails the PR instead of
-# slipping in silently. Make this a required status check in branch protection.
+# Template discipline gate. Runs two checks so drift across any family fails the
+# PR instead of slipping in silently:
+#   1. next-core.css sync — every family must ship a byte-identical shared base
+#      stylesheet (lint:next-core); no build needed, so it runs first / fails fast.
+#   2. SDK markup — builds all families and runs the catalog linter
+#      (lint:sdk:ci = lint-sdk.mjs --scope=all --pages=all) in source + rendered modes.
+# This job (`lint-sdk`) is a required status check in branch protection — keep the
+# job name stable so the required-check binding does not break.
 
 on:
   pull_request:
@@ -25,6 +29,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Lint next-core.css sync (all families identical)
+        run: npm run lint:next-core
       - name: Build all template families
         run: npm run build
       - name: Lint SDK markup (all families, source + rendered)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:sdk:shop-single-step:all": "node scripts/lint-sdk.mjs --scope=shop-single-step --pages=all",
     "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=all",
     "lint:sdk:promoted:all": "node scripts/lint-sdk.mjs --scope=promoted --pages=all",
+    "lint:next-core": "node scripts/lint-next-core-sync.mjs",
     "lint:agent-contracts": "node scripts/lint-agent-contracts.mjs"
   },
   "dependencies": {

--- a/scripts/lint-next-core-sync.mjs
+++ b/scripts/lint-next-core-sync.mjs
@@ -7,12 +7,20 @@
 // has historically drifted by hand (e.g. a shared rule added to some families
 // but not others), so this linter makes the invariant a hard gate.
 //
-// Files checked: src/<family>/assets/css/next-core.css
-//   (src/landing/ ships tokens.css only and is naturally excluded.)
+// Design notes:
+//   - The canonical family list is pinned (FAMILIES) and `olympus` is the fixed
+//     reference. We do NOT infer "correct" from a majority vote (4 families
+//     accidentally agreeing on bad content must not redefine the canonical) and
+//     we do NOT infer the family set from "who has the file" (deleting the file
+//     from N families would otherwise shrink the set and pass — a fail-open hole).
+//   - A family in FAMILIES that is missing next-core.css is a hard failure.
+//   - A src/<dir> that ships next-core.css but is NOT in FAMILIES is a hard
+//     failure too, so the pinned list cannot silently fall out of date.
+//   - Comparison is byte-exact on purpose: whitespace / line-ending / BOM
+//     differences are real drift we want to catch.
 //
 // USAGE
-//   node scripts/lint-next-core-sync.mjs        # report drift, exit 0
-//   CI=1 node scripts/lint-next-core-sync.mjs   # exit non-zero on drift
+//   node scripts/lint-next-core-sync.mjs   # exits non-zero on any drift (no "report only" mode)
 //
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -23,78 +31,86 @@ const srcRoot = join(repoRoot, 'src');
 
 const REL = 'assets/css/next-core.css';
 
+// Canonical template families that MUST ship an identical next-core.css.
+// Mirrors the promoted-family list in lint-sdk.mjs. (src/landing/ ships
+// tokens.css only and is intentionally absent.)
+const FAMILIES = [
+  'olympus',
+  'limos',
+  'demeter',
+  'shop-single-step',
+  'shop-three-step',
+  'olympus-mv-single-step',
+  'olympus-mv-two-step',
+];
+const CANONICAL = 'olympus'; // fixed reference — not a majority vote
+
 function sha(buf) {
   return createHash('sha256').update(buf).digest('hex');
 }
 
-// Discover every family that ships a next-core.css.
-const families = readdirSync(srcRoot, { withFileTypes: true })
-  .filter((e) => e.isDirectory())
-  .map((e) => e.name)
-  .filter((name) => existsSync(join(srcRoot, name, REL)))
-  .sort();
+console.log(`[lint-next-core] checking ${FAMILIES.length} families share an identical ${REL}`);
 
-console.log(`[lint-next-core] checking ${families.length} families share an identical ${REL}`);
+const failures = [];
 
-if (families.length < 2) {
-  console.log('[lint-next-core] PASS (fewer than 2 files — nothing to compare)');
-  process.exit(0);
-}
-
-const entries = families.map((family) => {
-  const path = join(srcRoot, family, REL);
-  const content = readFileSync(path);
-  return { family, path, content, hash: sha(content) };
-});
-
-// Group by hash; the largest group is the reference, the rest are drifted.
-const byHash = new Map();
-for (const e of entries) {
-  if (!byHash.has(e.hash)) byHash.set(e.hash, []);
-  byHash.get(e.hash).push(e);
-}
-
-if (byHash.size === 1) {
-  console.log('[lint-next-core] PASS — all next-core.css files are identical');
-  process.exit(0);
-}
-
-// Pick the reference group (most members; ties broken by first family alphabetically).
-const groups = [...byHash.values()].sort(
-  (a, b) => b.length - a.length || a[0].family.localeCompare(b[0].family),
-);
-const reference = groups[0];
-const refLines = reference[0].content.toString('utf8').split('\n');
-
-console.error(
-  `\n[lint-next-core] FAIL — next-core.css has drifted across families.\n` +
-    `  Reference (${reference.length}/${entries.length} agree): ${reference.map((e) => e.family).join(', ')}`,
-);
-
-for (const group of groups.slice(1)) {
-  for (const e of group) {
-    const lines = e.content.toString('utf8').split('\n');
-    // Find the first differing line to point the developer at the drift.
-    let firstDiff = -1;
-    const max = Math.max(lines.length, refLines.length);
-    for (let i = 0; i < max; i++) {
-      if (lines[i] !== refLines[i]) {
-        firstDiff = i;
-        break;
-      }
-    }
-    const where =
-      firstDiff === -1
-        ? 'differs only in length'
-        : `first diff at line ${firstDiff + 1}:\n      reference: ${JSON.stringify(refLines[firstDiff] ?? '<EOF>')}\n      ${e.family}: ${JSON.stringify(lines[firstDiff] ?? '<EOF>')}`;
-    console.error(`  ✗ ${relative(repoRoot, e.path)} (${lines.length} lines) — ${where}`);
+// 1. The pinned list must stay current: any family dir that ships next-core.css
+//    but isn't in FAMILIES means the list is stale.
+const onDisk = readdirSync(srcRoot, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && existsSync(join(srcRoot, e.name, REL)))
+  .map((e) => e.name);
+for (const dir of onDisk) {
+  if (!FAMILIES.includes(dir)) {
+    failures.push(`unknown family "${dir}" ships ${REL} but is not in the canonical FAMILIES list — add it to scripts/lint-next-core-sync.mjs`);
   }
 }
 
-console.error(
-  `\n  Fix: propagate the intended next-core.css to every family so all ${entries.length} files match.\n` +
-    `  Inspect with:  diff src/${reference[0].family}/${REL} src/<drifted-family>/${REL}\n`,
-);
+// 2. The canonical reference must exist.
+const canonicalPath = join(srcRoot, CANONICAL, REL);
+if (!existsSync(canonicalPath)) {
+  console.error(`\n[lint-next-core] FAIL — canonical reference missing: src/${CANONICAL}/${REL}`);
+  process.exit(1);
+}
+const refContent = readFileSync(canonicalPath);
+const refHash = sha(refContent);
+const refLines = refContent.toString('utf8').split('\n');
 
-// Drift is always a hard failure (locally and in CI).
+// 3. Every family must ship the file and match the canonical byte-for-byte.
+for (const family of FAMILIES) {
+  if (family === CANONICAL) continue;
+  const path = join(srcRoot, family, REL);
+  if (!existsSync(path)) {
+    failures.push(`${relative(repoRoot, path)} is MISSING (every family must ship next-core.css)`);
+    continue;
+  }
+  const content = readFileSync(path);
+  if (sha(content) === refHash) continue;
+
+  // Drift — point at the first differing line.
+  const lines = content.toString('utf8').split('\n');
+  let firstDiff = -1;
+  const max = Math.max(lines.length, refLines.length);
+  for (let i = 0; i < max; i++) {
+    if (lines[i] !== refLines[i]) {
+      firstDiff = i;
+      break;
+    }
+  }
+  const where =
+    firstDiff === -1
+      ? 'differs only in length'
+      : `first diff at line ${firstDiff + 1}:\n      ${CANONICAL}: ${JSON.stringify(refLines[firstDiff] ?? '<EOF>')}\n      ${family}: ${JSON.stringify(lines[firstDiff] ?? '<EOF>')}`;
+  failures.push(`${relative(repoRoot, path)} (${lines.length} lines) drifted from src/${CANONICAL}/${REL} — ${where}`);
+}
+
+if (failures.length === 0) {
+  console.log(`[lint-next-core] PASS — all ${FAMILIES.length} families match src/${CANONICAL}/${REL}`);
+  process.exit(0);
+}
+
+console.error(`\n[lint-next-core] FAIL — next-core.css is out of sync (${failures.length} issue${failures.length === 1 ? '' : 's'}):`);
+for (const f of failures) console.error(`  ✗ ${f}`);
+console.error(
+  `\n  Fix: propagate the intended next-core.css so every family matches the canonical (src/${CANONICAL}/${REL}).\n` +
+    `  Inspect with:  diff src/${CANONICAL}/${REL} src/<family>/${REL}\n`,
+);
 process.exit(1);

--- a/scripts/lint-next-core-sync.mjs
+++ b/scripts/lint-next-core-sync.mjs
@@ -1,0 +1,100 @@
+// lint-next-core-sync.mjs
+//
+// Asserts that every template family ships a byte-identical next-core.css.
+//
+// next-core.css is the shared base stylesheet — every family is meant to carry
+// the exact same file, and any change must be propagated to all of them. This
+// has historically drifted by hand (e.g. a shared rule added to some families
+// but not others), so this linter makes the invariant a hard gate.
+//
+// Files checked: src/<family>/assets/css/next-core.css
+//   (src/landing/ ships tokens.css only and is naturally excluded.)
+//
+// USAGE
+//   node scripts/lint-next-core-sync.mjs        # report drift, exit 0
+//   CI=1 node scripts/lint-next-core-sync.mjs   # exit non-zero on drift
+//
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const repoRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const srcRoot = join(repoRoot, 'src');
+
+const REL = 'assets/css/next-core.css';
+
+function sha(buf) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+// Discover every family that ships a next-core.css.
+const families = readdirSync(srcRoot, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name)
+  .filter((name) => existsSync(join(srcRoot, name, REL)))
+  .sort();
+
+console.log(`[lint-next-core] checking ${families.length} families share an identical ${REL}`);
+
+if (families.length < 2) {
+  console.log('[lint-next-core] PASS (fewer than 2 files — nothing to compare)');
+  process.exit(0);
+}
+
+const entries = families.map((family) => {
+  const path = join(srcRoot, family, REL);
+  const content = readFileSync(path);
+  return { family, path, content, hash: sha(content) };
+});
+
+// Group by hash; the largest group is the reference, the rest are drifted.
+const byHash = new Map();
+for (const e of entries) {
+  if (!byHash.has(e.hash)) byHash.set(e.hash, []);
+  byHash.get(e.hash).push(e);
+}
+
+if (byHash.size === 1) {
+  console.log('[lint-next-core] PASS — all next-core.css files are identical');
+  process.exit(0);
+}
+
+// Pick the reference group (most members; ties broken by first family alphabetically).
+const groups = [...byHash.values()].sort(
+  (a, b) => b.length - a.length || a[0].family.localeCompare(b[0].family),
+);
+const reference = groups[0];
+const refLines = reference[0].content.toString('utf8').split('\n');
+
+console.error(
+  `\n[lint-next-core] FAIL — next-core.css has drifted across families.\n` +
+    `  Reference (${reference.length}/${entries.length} agree): ${reference.map((e) => e.family).join(', ')}`,
+);
+
+for (const group of groups.slice(1)) {
+  for (const e of group) {
+    const lines = e.content.toString('utf8').split('\n');
+    // Find the first differing line to point the developer at the drift.
+    let firstDiff = -1;
+    const max = Math.max(lines.length, refLines.length);
+    for (let i = 0; i < max; i++) {
+      if (lines[i] !== refLines[i]) {
+        firstDiff = i;
+        break;
+      }
+    }
+    const where =
+      firstDiff === -1
+        ? 'differs only in length'
+        : `first diff at line ${firstDiff + 1}:\n      reference: ${JSON.stringify(refLines[firstDiff] ?? '<EOF>')}\n      ${e.family}: ${JSON.stringify(lines[firstDiff] ?? '<EOF>')}`;
+    console.error(`  ✗ ${relative(repoRoot, e.path)} (${lines.length} lines) — ${where}`);
+  }
+}
+
+console.error(
+  `\n  Fix: propagate the intended next-core.css to every family so all ${entries.length} files match.\n` +
+    `  Inspect with:  diff src/${reference[0].family}/${REL} src/<drifted-family>/${REL}\n`,
+);
+
+// Drift is always a hard failure (locally and in CI).
+process.exit(1);

--- a/scripts/lint-next-core-sync.mjs
+++ b/scripts/lint-next-core-sync.mjs
@@ -64,17 +64,23 @@ for (const dir of onDisk) {
   }
 }
 
-// 2. The canonical reference must exist.
+// 2. The canonical reference must exist. If it doesn't, we can't compute drift
+//    for the others — but we still run the presence sweep below so the report
+//    lists every missing file in one pass instead of bailing on the first.
 const canonicalPath = join(srcRoot, CANONICAL, REL);
-if (!existsSync(canonicalPath)) {
-  console.error(`\n[lint-next-core] FAIL — canonical reference missing: src/${CANONICAL}/${REL}`);
-  process.exit(1);
+const haveCanonical = existsSync(canonicalPath);
+let refHash = null;
+let refLines = [];
+if (!haveCanonical) {
+  failures.push(`canonical reference is MISSING: ${relative(repoRoot, canonicalPath)} — cannot compute drift for other families until it is restored`);
+} else {
+  const refContent = readFileSync(canonicalPath);
+  refHash = sha(refContent);
+  refLines = refContent.toString('utf8').split('\n');
 }
-const refContent = readFileSync(canonicalPath);
-const refHash = sha(refContent);
-const refLines = refContent.toString('utf8').split('\n');
 
-// 3. Every family must ship the file and match the canonical byte-for-byte.
+// 3. Every family must ship the file and (when the canonical exists) match it
+//    byte-for-byte.
 for (const family of FAMILIES) {
   if (family === CANONICAL) continue;
   const path = join(srcRoot, family, REL);
@@ -82,6 +88,7 @@ for (const family of FAMILIES) {
     failures.push(`${relative(repoRoot, path)} is MISSING (every family must ship next-core.css)`);
     continue;
   }
+  if (!haveCanonical) continue; // presence noted; drift uncheckable without a reference
   const content = readFileSync(path);
   if (sha(content) === refHash) continue;
 


### PR DESCRIPTION
Two maintenance-hardening additions, building on the `lint-sdk` CI gate (#92) and the now-enforced branch protection.

## 1. next-core.css cross-family sync gate
`scripts/lint-next-core-sync.mjs` asserts every template family ships a **byte-identical** `next-core.css` (the shared base stylesheet). This repo's recurring bug class is exactly this drift — a shared rule added to some families but not all (the pill-color tokens and `.order-bumps` rule in #88/#89 each had to be propagated by hand and caught in human review). This makes the invariant a hard gate.

- New npm script `lint:next-core`.
- Wired into the existing `lint-sdk` workflow as a **fast-fail step before build** (it reads `src/`, no build needed).
- On drift it names the majority reference and prints each drifted file + its first differing line; exits non-zero.
- Job name kept as `lint-sdk` so the **required status check binding is preserved**.

Verified: passes on the current in-sync tree (all 7 families identical); fails correctly with a pinpointed line when drift is injected.

## 2. Dependabot (npm + github-actions)
`.github/dependabot.yml` — weekly update PRs for npm deps (notably **`next-campaign-page-kit`** / the SDK pin) and the workflow actions. Minor/patch grouped to cut noise; majors open individually. Every Dependabot PR runs through the `lint-sdk` gate, so a breaking bump fails its own PR — nothing auto-merges.

## Note
This PR is the first to run under the newly-required `lint-sdk` check — it gates itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
