### PR TITLE
docs: add 'Adding a new template family' checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,9 @@ repo-root/
 ```
 
 ## Adding a new template family
-When adding a new `src/<slug>/` family, update these together or CI (`lint-sdk` gate) fails:
+When adding a new `src/<slug>/` family, update these together or the **`lint-sdk` CI gate** fails. (That CI job — `.github/workflows/lint-sdk.yml` — runs two separate linters as steps: `lint:next-core` → `scripts/lint-next-core-sync.mjs`, and `lint:sdk:ci` → `scripts/lint-sdk.mjs`.)
 1. `templates.json` — add the picker-registry entry (see File Structure note above).
-2. `scripts/lint-next-core-sync.mjs` — add the slug to the `FAMILIES` list. The gate asserts every family ships a **byte-identical** `next-core.css`; an unlisted family that ships one fails with `unknown family … not in the canonical FAMILIES list`, and the new file must match the canonical (`src/olympus/assets/css/next-core.css`).
+2. `scripts/lint-next-core-sync.mjs` — add the slug to the `FAMILIES` list. The `lint:next-core` linter asserts every family ships a **byte-identical** `next-core.css`; an unlisted family that ships one fails with `unknown family … not in the canonical FAMILIES list`, and the new file must match the canonical (`src/olympus/assets/css/next-core.css`).
 3. Preview-URL / inventory tables in this file and `README.md`, if you want it listed.
 
 ## Each src/[slug]/ Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ repo-root/
 └── package.json                ← kit scripts + next-campaign-page-kit dependency
 ```
 
+## Adding a new template family
+When adding a new `src/<slug>/` family, update these together or CI (`lint-sdk` gate) fails:
+1. `templates.json` — add the picker-registry entry (see File Structure note above).
+2. `scripts/lint-next-core-sync.mjs` — add the slug to the `FAMILIES` list. The gate asserts every family ships a **byte-identical** `next-core.css`; an unlisted family that ships one fails with `unknown family … not in the canonical FAMILIES list`, and the new file must match the canonical (`src/olympus/assets/css/next-core.css`).
+3. Preview-URL / inventory tables in this file and `README.md`, if you want it listed.
+
 ## Each src/[slug]/ Structure
 ```
 [slug]/


### PR DESCRIPTION
Adds a short **"Adding a new template family"** checklist to `CLAUDE.md`, right after the File Structure block.

## Why
The next-core sync gate (#94) pins a canonical `FAMILIES` list in `scripts/lint-next-core-sync.mjs`. A newly-added family that isn't in that list fails the `lint-sdk` build (`unknown family … not in the canonical FAMILIES list`). The linter's error message already self-documents the fix, but nothing made it *discoverable before* CI fails — this consolidates the things that must move together when adding a family (templates.json + FAMILIES + the new file matching the canonical).

## Scope
- `CLAUDE.md` only — **not** `docs/campaign-page-kit-template-context.md` (that downstream file is the copyable rules for developers working in their own kit projects; the `FAMILIES` list is an internal concern of this repo).
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
