### PR TITLE
fix(core): full-width bundle price row on mobile only

### DIFF
--- a/src/apollo-mv-single-step/assets/css/next-core.css
+++ b/src/apollo-mv-single-step/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/apollo-mv-single-step/assets/css/next-core.css
+++ b/src/apollo-mv-single-step/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/apollo/assets/css/next-core.css
+++ b/src/apollo/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/apollo/assets/css/next-core.css
+++ b/src/apollo/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/demeter/assets/css/next-core.css
+++ b/src/demeter/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/demeter/assets/css/next-core.css
+++ b/src/demeter/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/limos/assets/css/next-core.css
+++ b/src/limos/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/limos/assets/css/next-core.css
+++ b/src/limos/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/olympus-mv-single-step/assets/css/next-core.css
+++ b/src/olympus-mv-single-step/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/olympus-mv-single-step/assets/css/next-core.css
+++ b/src/olympus-mv-single-step/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/olympus-mv-two-step/assets/css/next-core.css
+++ b/src/olympus-mv-two-step/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/olympus-mv-two-step/assets/css/next-core.css
+++ b/src/olympus-mv-two-step/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/olympus/assets/css/next-core.css
+++ b/src/olympus/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/olympus/assets/css/next-core.css
+++ b/src/olympus/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/shop-single-step/assets/css/next-core.css
+++ b/src/shop-single-step/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/shop-single-step/assets/css/next-core.css
+++ b/src/shop-single-step/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;

--- a/src/shop-three-step/assets/css/next-core.css
+++ b/src/shop-three-step/assets/css/next-core.css
@@ -12752,20 +12752,6 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   margin-top: 1rem;
 }
 
-@media (max-width: 991px) {
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
-    grid-column-gap: 1rem;
-    grid-row-gap: .75rem;
-    grid-template-columns: auto auto minmax(0, 1fr);
-  }
-
-  [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
-    align-items: flex-start;
-    grid-column: 3;
-    text-align: left;
-  }
-}
-
 @media (max-width: 767px) {
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-card--product {
     padding: .875rem;
@@ -12773,6 +12759,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__main {
     grid-column-gap: .75rem;
+    grid-row-gap: .175rem;
     grid-template-columns: auto 72px minmax(0, 1fr);
   }
 
@@ -12787,7 +12774,7 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
 
   [data-component="prepurchase-upsell"][data-variant="check03"] .bump-product__price {
     align-items: flex-start;
-    grid-column: 3;
+    grid-column: 1 / -1;
     text-align: left;
   }
 

--- a/src/shop-three-step/assets/css/next-core.css
+++ b/src/shop-three-step/assets/css/next-core.css
@@ -15873,8 +15873,8 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   font-weight: 700;
 }
 
-/* Responsive: stack price under copy, smaller image ---------------------- */
-@media screen and (max-width: 991px) {
+/* Responsive: stack price on its own row at mobile only ----------------- */
+@media screen and (max-width: 767px) {
   .bundle-card__main {
     grid-template-columns: auto auto minmax(0, 1fr);
     column-gap: 1rem;
@@ -15882,13 +15882,11 @@ os-dropdown[next-variant-option="color"] os-dropdown-item.next-oos::after {
   }
 
   .bundle-card__price {
-    grid-column: 3;
+    grid-column: 1 / -1;
     align-items: flex-start;
     text-align: left;
   }
-}
 
-@media screen and (max-width: 767px) {
   .bundle-card__image {
     width: 64px;
     height: 64px;


### PR DESCRIPTION
## Summary
- Product bundle cards (`bundle_card_style: product`) keep the single inline row (`radio | image | title | price`) above **767px** — tablet no longer stacks price under the title at 991px.
- At **≤767px**, price + instant savings move to their own full-width row (`grid-column: 1 / -1`).
- Synced across all nine `next-core.css` families (`lint:next-core` passes).

## Test plan
- [x] Apollo checkout with `bundle_card_style: "product"` — desktop/tablet: one row; phone: price row full width
- [x] Confirm tiles/classic bundle styles unaffected
- [x] `npm run lint:next-core`


Made with [Cursor](https://cursor.com)