### PR TITLE
Track issues on the Operations org board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,22 @@
+name: Add to Operations board
+
+on:
+  issues:
+    types: [opened, reopened]
+
+# No GITHUB_TOKEN needed — the add-to-project step authenticates with the
+# ADD_TO_PROJECT_PAT org secret.
+permissions: {}
+
+jobs:
+  add-to-project:
+    # Only auto-add issues authored by org owners/members/collaborators —
+    # outsider-authored issues in public repos need human triage onto the board.
+    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/orgs/NextCommerceCo/projects/10
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,3 +369,15 @@ Design decisions:
 - **Auto-delivery shipped in CPK 0.2.0**: `campaign-init --ai-context claude|codex|cursor|copilot` now installs this doc verbatim into developer projects (with a sentinel header, overwritten on re-run unless `--keep-ai-context`). This file is the upstream source — keeping it correct now directly shapes downstream AI context.
 
 README has an "AI development rules" section pointing developers to copy `docs/campaign-page-kit-template-context.md` into their project.
+## Issue tracking
+
+Work in this repo is tracked with GitHub Issues and coordinated on the
+org-level **[Operations](https://github.com/orgs/NextCommerceCo/projects/10)**
+Kanban board (Todo / In Progress / Done). New issues are added to the board
+automatically by the `add-to-project` workflow.
+
+Before starting work on an issue: check it is not assigned to someone else,
+assign yourself (`gh issue edit <n> --add-assignee @me`), and move the card to
+In Progress. Open PRs with `Closes #<n>`; when the issue closes on merge, the
+board's built-in "Item closed" automation moves the card to Done. Contributors
+have a `/next-board` skill that wraps these board operations.


### PR DESCRIPTION
Adds this repo to the org-level **[Operations](https://github.com/orgs/NextCommerceCo/projects/10)** Kanban board (Todo / In Progress / Done).

- `.github/workflows/add-to-project.yml` — auto-adds opened/reopened issues (hardened: SHA-pinned action, `permissions: {}`, author-association gate, `timeout-minutes: 5`)
- Board note documenting the claim protocol for agent sessions

**Prerequisite:** the org Actions secret `ADD_TO_PROJECT_PAT` must be shared to this repo (fine-grained PAT, org Projects read/write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)