### PR TITLE
presell: conditional proof/urgency sections; rating literal becomes a slot

### DIFF
--- a/docs/pre-checkout-pages.md
+++ b/docs/pre-checkout-pages.md
@@ -196,6 +196,14 @@ data-watch-overflow  hide controls when locked (default: false)
 Children: `[data-swiper]` (the .swiper el), `[data-swiper-prev]`, `[data-swiper-next]`, `[data-swiper-controls]` (hides when locked), `.swiper-pagination`
 
 ### Countdown timer
+
+The presell countdown block, sell-out bar, byline row, and star-rating row are
+conditional: each renders only when its frontmatter slot is non-empty
+(`countdown_label`, `sell_out_risk`/`shipping_text`, `author_name`,
+`article_rating_text`). An empty slot means the section is absent, not empty
+chrome. Demo values show the shape of typical content; per-slot sourcing rules
+live in the campaigns-os template slot manifest.
+
 ```
 [data-countdown]               wrapper
   data-duration-minutes        timer length (default: 15)

--- a/src/apollo-mv-single-step/presell.html
+++ b/src/apollo-mv-single-step/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/apollo-mv-single-step/presell.html
+++ b/src/apollo-mv-single-step/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/apollo/presell.html
+++ b/src/apollo/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/apollo/presell.html
+++ b/src/apollo/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/demeter/presell.html
+++ b/src/demeter/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/demeter/presell.html
+++ b/src/demeter/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/olympus-mv-single-step/presell.html
+++ b/src/olympus-mv-single-step/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/olympus-mv-single-step/presell.html
+++ b/src/olympus-mv-single-step/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/olympus-mv-two-step/presell.html
+++ b/src/olympus-mv-two-step/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/olympus-mv-two-step/presell.html
+++ b/src/olympus-mv-two-step/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/olympus/presell.html
+++ b/src/olympus/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/olympus/presell.html
+++ b/src/olympus/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/shop-single-step/presell.html
+++ b/src/shop-single-step/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/shop-single-step/presell.html
+++ b/src/shop-single-step/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}

--- a/src/shop-three-step/presell.html
+++ b/src/shop-three-step/presell.html
@@ -14,6 +14,7 @@ author_name: "Sarah Mitchell"
 author_publication: "Wellness Insider"
 author_date: "March 15, 2026"
 read_time: "6 min read"
+article_rating_text: "4.9/5 (1,247 reviews)"
 
 # Promo bar
 promo_headline: "SPRING SALE"
@@ -101,27 +102,42 @@ footer_copyright: "Copyright ©2026 Next Commerce"
     <h1 class="font-bold text-[32px] md:text-[44px] leading-tight text-[var(--text-primary)] mb-5">
       {{ article_title }}
     </h1>
-    <!-- Author row -->
+    <!-- Author row (renders only when author_name is set) -->
+    {% if author_name and author_name != "" %}
     <div class="flex items-center gap-3 mb-4">
       <img src="{{ 'images/presell/author-avatar.png' | campaign_asset }}" alt="{{ author_name }}" class="w-10 h-10 rounded-full object-cover shrink-0">
       <div class="text-sm text-[var(--text-secondary)]">
         <span class="italic">by</span>
         <strong class="text-[var(--text-primary)] not-italic ml-1">{{ author_name }}</strong>
+        {% if author_publication and author_publication != "" %}
         <span class="mx-1">·</span>
         <span>{{ author_publication }}</span>
+        {% endif %}
+        {% if author_date and author_date != "" %}
         <span class="mx-1">·</span>
         <span>Updated {{ author_date }}</span>
+        {% endif %}
       </div>
     </div>
-    <!-- Star rating + read time -->
+    {% endif %}
+    <!-- Star rating + read time (rating chrome renders only when article_rating_text is set) -->
+    {%- capture _article_meta -%}{{ article_rating_text }}{{ read_time }}{%- endcapture -%}
+    {% if _article_meta != "" %}
     <div class="flex items-center gap-3 mb-5 text-sm">
+      {% if article_rating_text and article_rating_text != "" %}
       <div class="flex items-center gap-0.5 text-[#f59e0b]">
         <span>★★★★★</span>
       </div>
-      <span class="text-[var(--text-secondary)]">4.9/5 (1,247 reviews)</span>
+      <span class="text-[var(--text-secondary)]">{{ article_rating_text }}</span>
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--border-default)]">|</span>
+      {% endif %}
+      {% endif %}
+      {% if read_time and read_time != "" %}
       <span class="text-[var(--text-secondary)]">{{ read_time }}</span>
+      {% endif %}
     </div>
+    {% endif %}
     <!-- Bold summary -->
     <p class="text-[17px] md:text-[18px] font-semibold text-[var(--text-primary)] leading-[1.6]">
       {{ article_subtitle }}
@@ -389,18 +405,29 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <img src="{{ 'images/presell/_shared/arrow-right.svg' | campaign_asset }}" alt="" class="w-[18px] h-[14px] brightness-0 invert">
           </a>
 
-          <!-- Countdown -->
+          <!-- Countdown (renders only when countdown_label is set) -->
+          {% if countdown_label and countdown_label != "" %}
           <div class="flex items-center gap-1 text-[14px] font-extrabold">
             <span class="text-[var(--text-primary)]">{{ countdown_label }}</span>
             <span class="text-[#b70101]"><span data-countdown-hrs>02</span>:<span data-countdown-min>02</span>:<span data-countdown-sec>09</span></span>
           </div>
+          {% endif %}
 
-          <!-- Sell-out / shipping bar -->
+          <!-- Sell-out / shipping bar (each half renders only when its slots are set; bar absent when both empty) -->
+          {%- capture _urgency_bar -%}{{ sell_out_risk }}{{ shipping_text }}{%- endcapture -%}
+          {% if _urgency_bar != "" %}
           <div class="w-full bg-[#ffe7e7] rounded px-4 py-2 flex items-center justify-center gap-3 text-[14px]">
+            {% if sell_out_risk and sell_out_risk != "" %}
             <span class="font-medium text-[var(--text-primary)]">{{ sell_out_text }} <strong class="text-[#b70101]">{{ sell_out_risk }}</strong></span>
+            {% endif %}
+            {% if sell_out_risk and sell_out_risk != "" and shipping_text and shipping_text != "" %}
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
+            {% endif %}
+            {% if shipping_text and shipping_text != "" %}
             <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            {% endif %}
           </div>
+          {% endif %}
 
           <!-- Guarantee -->
           <div class="flex items-center gap-2">

--- a/src/shop-three-step/presell.html
+++ b/src/shop-three-step/presell.html
@@ -424,7 +424,7 @@ footer_copyright: "Copyright ©2026 Next Commerce"
             <span class="w-px h-4 bg-[var(--border-default)] shrink-0"></span>
             {% endif %}
             {% if shipping_text and shipping_text != "" %}
-            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong> {{ shipping_label }}</span>
+            <span class="font-medium text-[var(--text-primary)]"><strong>{{ shipping_text }}</strong>{% if shipping_label and shipping_label != "" %} {{ shipping_label }}{% endif %}</span>
             {% endif %}
           </div>
           {% endif %}


### PR DESCRIPTION
## What

Three small behavior changes to the presell page, across all 8 families (copies stay byte-identical). **Demo content is untouched** — demo values keep showing the shape of typical presell content, and previews render exactly as before.

1. **Conditional sections** — the byline row, star-rating row, countdown block, and sell-out bar now render only when their frontmatter slots are non-empty (house `{% if slot and slot != "" %}` idiom). A blank slot means the section is absent. Today, blanking `countdown_label` still ships a live ticking countdown under the CTA, and clearing the sell-out slots leaves an empty red strip — this closes both.
2. **The rating literal becomes a slot** — the hardcoded `4.9/5 (1,247 reviews)` next to the stars is now the `article_rating_text` frontmatter slot (demo value identical), so campaign builds can set or omit it like every other content variable instead of inheriting the demo number.
3. **Docs** — a conditional-rendering note in `docs/pre-checkout-pages.md`.

## Why

Campaigns cloned from these templates keep shipping demo proof/urgency chrome they didn't mean to (a countdown with no real promotion behind it, the demo review count). Making these sections slot-gated means a campaign that doesn't supply a value simply doesn't render the surface. The per-slot semantics (which slots are label/value pairs, what should fill them) are being formalized as a content-slot contract on the campaigns-os side (NextCommerceCo/campaigns-os#153), which also adds a doctor check that flags leftover demo values in built output.

## Not touched

Demo frontmatter values, `next-core.css`, commerce surfaces (`data-next-*`), checkout/upsell/receipt pages.

## Verification

- `npm run build` green (66 pages); demo presell renders the full design unchanged.
- `lint:next-core`, `lint:shared`, `lint:sdk` all PASS.
- With the new slots blanked: countdown, rating chrome, and sell-out half all absent from rendered output; shipping chip renders standalone; no orphan spacing.
- Kilo review findings addressed (one fix, two answered on the threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)