### PR TITLE
fix(ci): Operations-board auto-add skips private org members

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,19 +4,61 @@ on:
   issues:
     types: [opened, reopened]
 
-# No GITHUB_TOKEN needed — the add-to-project step authenticates with the
+# No GITHUB_TOKEN needed — both steps authenticate with the
 # ADD_TO_PROJECT_PAT org secret.
 permissions: {}
 
 jobs:
   add-to-project:
-    # Only auto-add issues authored by org owners/members/collaborators —
-    # outsider-authored issues in public repos need human triage onto the board.
-    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Only auto-add issues authored by org members — outsider-authored
+      # issues in public repos need human triage onto the board.
+      #
+      # The event payload's author_association reports NONE/CONTRIBUTOR for
+      # org members whose membership is private, so it cannot be the only
+      # gate: accept it when it already says OWNER/MEMBER/COLLABORATOR,
+      # otherwise fall back to a live org-membership check with the PAT.
+      - name: Gate on org membership
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          ASSOCIATION: ${{ github.event.issue.author_association }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::ADD_TO_PROJECT_PAT is empty. Org secrets do not reach private repos on the GitHub Free plan — set a repo-level Actions secret named ADD_TO_PROJECT_PAT with the same PAT value."
+            exit 1
+          fi
+          case "$ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "author=$AUTHOR association=$ASSOCIATION — adding to board"
+              echo "ok=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              status=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/orgs/NextCommerceCo/members/$AUTHOR")
+              case "$status" in
+                204)
+                  echo "author=$AUTHOR is an org member (association=$ASSOCIATION, likely private membership) — adding to board"
+                  echo "ok=true" >> "$GITHUB_OUTPUT"
+                  ;;
+                404)
+                  echo "author=$AUTHOR is not an org member — leaving for human triage"
+                  echo "ok=false" >> "$GITHUB_OUTPUT"
+                  ;;
+                *)
+                  echo "::error::Org-membership check for $AUTHOR returned HTTP $status. If 403, the ADD_TO_PROJECT_PAT likely lacks the read:org scope."
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        if: steps.gate.outputs.ok == 'true'
         with:
           project-url: https://github.com/orgs/NextCommerceCo/projects/10
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Problem
Issues authored by org members with **private** org membership never reach [Project 10 (Operations)](https://github.com/orgs/NextCommerceCo/projects/10): the `issues` event payload computes `author_association` from a public viewpoint, so private members show as `NONE`/`CONTRIBUTOR` and the job-level `if:` gate skips (campaigns-os run 29989815318 for #155; starter-templates run 29329489071 for #108).

## Fix
- Replace the payload-only job gate with a gate step: accept `OWNER`/`MEMBER`/`COLLABORATOR` from the payload directly, otherwise check live org membership (`GET /orgs/NextCommerceCo/members/{author}`) with the PAT. Non-members still skip → human triage unchanged.
- Fail loudly with remediation text when `ADD_TO_PROJECT_PAT` resolves empty (the next-campaigns-ops failure mode: org secrets don't reach private repos on the Free plan) or when the membership check errors (e.g. PAT missing `read:org`).

Same change lands in campaigns-os, next-campaigns-ops, and campaign-cart-starter-templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)