### PR TITLE
fix(ci): board auto-add gate — collaborator check instead of org-members endpoint

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,8 +4,9 @@ on:
   issues:
     types: [opened, reopened]
 
-# No GITHUB_TOKEN needed — both steps authenticate with the
-# ADD_TO_PROJECT_PAT org secret.
+# The gate step only needs the built-in token's implicit metadata:read;
+# the add-to-project step authenticates with the ADD_TO_PROJECT_PAT org
+# secret (project scope).
 permissions: {}
 
 jobs:
@@ -13,45 +14,57 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Only auto-add issues authored by org members — outsider-authored
-      # issues in public repos need human triage onto the board.
+      # Only auto-add issues authored by org members/collaborators —
+      # outsider-authored issues in public repos need human triage.
       #
       # The event payload's author_association reports NONE/CONTRIBUTOR for
       # org members whose membership is private, so it cannot be the only
       # gate: accept it when it already says OWNER/MEMBER/COLLABORATOR,
-      # otherwise fall back to a live org-membership check with the PAT.
-      - name: Gate on org membership
+      # otherwise check repo-collaborator status live. The collaborators
+      # endpoint includes org members with access via org/team permissions
+      # and needs only metadata:read, which every GITHUB_TOKEN has (the org
+      # members endpoint would need a PAT with read:org, which
+      # ADD_TO_PROJECT_PAT lacks — it returned HTTP 302 in run 29990823853).
+      - name: Gate on collaborator status
         id: gate
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GH_TOKEN: ${{ github.token }}
+          PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
           AUTHOR: ${{ github.event.issue.user.login }}
           ASSOCIATION: ${{ github.event.issue.author_association }}
         run: |
-          if [ -z "$GH_TOKEN" ]; then
+          if [ -z "$PAT" ]; then
             echo "::error::ADD_TO_PROJECT_PAT is empty. Org secrets do not reach private repos on the GitHub Free plan — set a repo-level Actions secret named ADD_TO_PROJECT_PAT with the same PAT value."
             exit 1
           fi
+          check() {
+            curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $1" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/$AUTHOR"
+          }
           case "$ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR)
               echo "author=$AUTHOR association=$ASSOCIATION — adding to board"
               echo "ok=true" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              status=$(curl -s -o /dev/null -w "%{http_code}" \
-                -H "Authorization: Bearer $GH_TOKEN" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/orgs/NextCommerceCo/members/$AUTHOR")
-              case "$status" in
+              code=$(check "$GH_TOKEN")
+              if [ "$code" != "204" ] && [ "$code" != "404" ]; then
+                echo "GITHUB_TOKEN collaborator check returned HTTP $code; retrying with PAT"
+                code=$(check "$PAT")
+              fi
+              case "$code" in
                 204)
-                  echo "author=$AUTHOR is an org member (association=$ASSOCIATION, likely private membership) — adding to board"
+                  echo "author=$AUTHOR is a collaborator (association=$ASSOCIATION, likely private org membership) — adding to board"
                   echo "ok=true" >> "$GITHUB_OUTPUT"
                   ;;
                 404)
-                  echo "author=$AUTHOR is not an org member — leaving for human triage"
+                  echo "author=$AUTHOR is not a collaborator — leaving for human triage"
                   echo "ok=false" >> "$GITHUB_OUTPUT"
                   ;;
                 *)
-                  echo "::error::Org-membership check for $AUTHOR returned HTTP $status. If 403, the ADD_TO_PROJECT_PAT likely lacks the read:org scope."
+                  echo "::error::Collaborator check for $AUTHOR returned HTTP $code with both tokens."
                   exit 1
                   ;;
               esac


### PR DESCRIPTION
Follow-up to the previous add-to-project gate fix: the live org-membership check used `GET /orgs/NextCommerceCo/members/{author}`, which requires `read:org` — a scope `ADD_TO_PROJECT_PAT` doesn't have. The check returned HTTP 302 and failed the run (verification run 29990823853 on starter-templates, where the event payload showed `author_association: CONTRIBUTOR` for next-devin, confirming the private-membership diagnosis).

This switches the gate to `GET /repos/{repo}/collaborators/{author}` — includes org members with access via org/team permissions, and needs only `metadata:read`, which the built-in `GITHUB_TOKEN` always has (PAT retry as fallback). Verified from a workstation: next-devin → 204, outside user → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)