### PR TITLE
fix(ci): board auto-add gate — PAT collaborator check with scope introspection

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,9 +4,8 @@ on:
   issues:
     types: [opened, reopened]
 
-# The gate step only needs the built-in token's implicit metadata:read;
-# the add-to-project step authenticates with the ADD_TO_PROJECT_PAT org
-# secret (project scope).
+# Both steps authenticate with the ADD_TO_PROJECT_PAT org secret
+# (classic PAT; needs repo + project scopes).
 permissions: {}
 
 jobs:
@@ -19,55 +18,68 @@ jobs:
       #
       # The event payload's author_association reports NONE/CONTRIBUTOR for
       # org members whose membership is private, so it cannot be the only
-      # gate: accept it when it already says OWNER/MEMBER/COLLABORATOR,
-      # otherwise check repo-collaborator status live. The collaborators
-      # endpoint includes org members with access via org/team permissions
-      # and needs only metadata:read, which every GITHUB_TOKEN has (the org
-      # members endpoint would need a PAT with read:org, which
-      # ADD_TO_PROJECT_PAT lacks — it returned HTTP 302 in run 29990823853).
+      # gate. Two dead ends, both observed on real runs: the org-members
+      # endpoint needs read:org, which the PAT lacks (HTTP 302, run
+      # 29990823853); and GITHUB_TOKEN answers the collaborators endpoint
+      # with a false 404 for collaborators whose access derives from org
+      # roles (run 29991353247). So: check the collaborators endpoint with
+      # the PAT, and only trust a 404 when the token's advertised scopes
+      # prove it could actually see the collaborator list — otherwise fail
+      # loudly instead of silently skipping.
       - name: Gate on collaborator status
         id: gate
         env:
-          GH_TOKEN: ${{ github.token }}
           PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
           AUTHOR: ${{ github.event.issue.user.login }}
           ASSOCIATION: ${{ github.event.issue.author_association }}
+          REPO_PRIVATE: ${{ github.event.repository.private }}
         run: |
           if [ -z "$PAT" ]; then
             echo "::error::ADD_TO_PROJECT_PAT is empty. Org secrets do not reach private repos on the GitHub Free plan — set a repo-level Actions secret named ADD_TO_PROJECT_PAT with the same PAT value."
             exit 1
           fi
-          check() {
-            curl -s -o /dev/null -w "%{http_code}" \
-              -H "Authorization: Bearer $1" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/$AUTHOR"
-          }
           case "$ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR)
               echo "author=$AUTHOR association=$ASSOCIATION — adding to board"
               echo "ok=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          headers=$(curl -s -D - -o /dev/null \
+            -H "Authorization: Bearer $PAT" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/$AUTHOR" | tr -d '\r')
+          code=$(printf '%s\n' "$headers" | head -1 | cut -d' ' -f2)
+          scopes=$(printf '%s\n' "$headers" | grep -i '^x-oauth-scopes:' | cut -d: -f2- | sed 's/^ *//')
+          echo "collaborator check: HTTP $code (PAT scopes: ${scopes:-none advertised / fine-grained})"
+          case "$code" in
+            204)
+              echo "author=$AUTHOR is a collaborator (association=$ASSOCIATION, likely private org membership) — adding to board"
+              echo "ok=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              # A 404 is only authoritative if the PAT could see the repo's
+              # collaborators at all: full repo scope always can; public_repo
+              # suffices on public repos. Anything else is indistinguishable
+              # from a scope problem — fail loudly.
+              if printf '%s' "$scopes" | grep -qE '(^|, )repo(,|$)'; then
+                authoritative=true
+              elif [ "$REPO_PRIVATE" = "false" ] && printf '%s' "$scopes" | grep -qE '(^|, )public_repo(,|$)'; then
+                authoritative=true
+              else
+                authoritative=false
+              fi
+              if [ "$authoritative" = "true" ]; then
+                echo "author=$AUTHOR is not a collaborator — leaving for human triage"
+                echo "ok=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "::error::Collaborator check returned 404 but ADD_TO_PROJECT_PAT does not advertise a repo scope that could see this repo's collaborators (scopes: ${scopes:-none}). Grant the PAT repo scope (or repo access, if fine-grained) so the gate can distinguish outsiders from scope failures."
+                exit 1
+              fi
               ;;
             *)
-              code=$(check "$GH_TOKEN")
-              if [ "$code" != "204" ] && [ "$code" != "404" ]; then
-                echo "GITHUB_TOKEN collaborator check returned HTTP $code; retrying with PAT"
-                code=$(check "$PAT")
-              fi
-              case "$code" in
-                204)
-                  echo "author=$AUTHOR is a collaborator (association=$ASSOCIATION, likely private org membership) — adding to board"
-                  echo "ok=true" >> "$GITHUB_OUTPUT"
-                  ;;
-                404)
-                  echo "author=$AUTHOR is not a collaborator — leaving for human triage"
-                  echo "ok=false" >> "$GITHUB_OUTPUT"
-                  ;;
-                *)
-                  echo "::error::Collaborator check for $AUTHOR returned HTTP $code with both tokens."
-                  exit 1
-                  ;;
-              esac
+              echo "::error::Collaborator check for $AUTHOR returned HTTP $code with the PAT."
+              exit 1
               ;;
           esac
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2


### PR DESCRIPTION
Round 3 of the Operations-board auto-add fix, driven by two observed failures:
- The org-members endpoint needs `read:org`, which `ADD_TO_PROJECT_PAT` lacks (HTTP 302, run 29990823853).
- `GITHUB_TOKEN` answers `GET /repos/{repo}/collaborators/{user}` with a **false 404** for collaborators whose access derives from org roles (run 29991353247) — so the gate silently skipped org members again.

Now the gate checks the collaborators endpoint **with the PAT** (verified from a workstation that a classic `repo`-scoped token answers 204/404 correctly, including org-role-derived access), and only trusts a 404 when the token's advertised `X-OAuth-Scopes` prove it could see the collaborator list. Every ambiguous outcome fails the run loudly with remediation text instead of silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)