### PR TITLE
fix(ci): skip Operations-board automation outside NextCommerceCo

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,12 +7,13 @@ on:
 # Both steps authenticate with the ADD_TO_PROJECT_PAT org secret. It is a
 # fine-grained PAT (since 2026-07-23), so it advertises no X-OAuth-Scopes
 # header at all — never gate behaviour on token scope strings here. It
-# carries access to this repo, Issues: Read for the gate, and org
-# Projects: Read & Write for the add step.
+# carries access to this repo, Metadata: Read for the gate, Issues: Read
+# for issue lookup, and org Projects: Read & Write for the add step.
 permissions: {}
 
 jobs:
   add-to-project:
+    if: github.repository_owner == 'NextCommerceCo'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Follow-up to the fine-grained-PAT gate fixes. This prevents public template forks from running an org-specific job with missing org secrets, and corrects the permission comment: collaborator APIs require Metadata: Read; Issues: Read serves issue lookup. No runtime gate or token behavior changes. Applied in lockstep across all three workflow copies.

## Acceptance checks

- **YAML parses:** `python3` `yaml.safe_load` OK; `actionlint` clean on `.github/workflows/add-to-project.yml`.
- **Repo suite:** `npm run lint:next-core` PASS (all 8 families share a byte-identical `next-core.css`); `npm run lint:sdk:ci` PASS (source + rendered modes, scope=all).
- **Diff scope:** the diff touches only `.github/workflows/add-to-project.yml` — the job-level owner guard (`if: github.repository_owner == 'NextCommerceCo'`) and the corrected token-permission comment. The existing `actions/add-to-project` pin is untouched.
- **Byte-identity across the three live copies:** after normalizing the `uses: actions/add-to-project@<sha> # v<x.y.z>` line to `@PIN`, the workflow bodies in campaign-cart-starter-templates, campaigns-os, and next-campaigns-ops all hash to sha256 `ffaec48099e51c89b5b9eb233d48b7a4b2c927998128d951adba2ed5a6d1176d` (campaigns-os and next-campaigns-ops are byte-identical even before normalization).
- **Owner-guard logic (static eval):** in a fork `someowner/<repo>`, the `github.repository_owner` context is `someowner`, so `github.repository_owner == 'NextCommerceCo'` evaluates false and the job is skipped before any step runs — the empty-secret loud failure can no longer fire on forks. In this repo the owner is `NextCommerceCo`, so the expression is true and behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
