### PR TITLE
refactor(ci): use an org GitHub App for Operations automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,11 +4,9 @@ on:
   issues:
     types: [opened, reopened]
 
-# Both steps authenticate with the ADD_TO_PROJECT_PAT org secret. It is a
-# fine-grained PAT (since 2026-07-23), so it advertises no X-OAuth-Scopes
-# header at all — never gate behaviour on token scope strings here. It
-# carries access to this repo, Metadata: Read for the gate, Issues: Read
-# for issue lookup, and org Projects: Read & Write for the add step.
+# The gate and add step share a short-lived GitHub App installation token,
+# narrowed to Metadata: Read, Issues: Read, and org Projects: Write. The token
+# is scoped to this repository and revoked automatically when the job ends.
 permissions: {}
 
 jobs:
@@ -17,30 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.NEXTCOMMERCE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NEXTCOMMERCE_AUTOMATION_APP_PRIVATE_KEY }}
+          permission-metadata: read
+          permission-issues: read
+          permission-organization-projects: write
       # Only auto-add issues authored by org members/collaborators —
       # outsider-authored issues in public repos need human triage.
       #
       # The event payload's author_association reports NONE/CONTRIBUTOR for
       # org members whose membership is private, so it cannot be the only
-      # gate. Two dead ends, both observed on real runs: the org-members
-      # endpoint needs read:org, which the PAT lacks (HTTP 302, run
-      # 29990823853); and GITHUB_TOKEN answers the collaborators endpoint
-      # with a false 404 for collaborators whose access derives from org
-      # roles (run 29991353247). So: check the collaborators endpoint with
-      # the PAT, and only trust a 404 when a probe proves the token can
-      # actually read this repo's collaborator list — otherwise fail loudly
-      # instead of silently skipping.
+      # gate. Ask GitHub for the author's effective repository permission,
+      # which includes direct, team, org-default, and enterprise grants.
       - name: Gate on collaborator status
         id: gate
         env:
-          PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AUTHOR: ${{ github.event.issue.user.login }}
           ASSOCIATION: ${{ github.event.issue.author_association }}
         run: |
-          if [ -z "$PAT" ]; then
-            echo "::error::ADD_TO_PROJECT_PAT is empty. Org secrets do not reach private repos on the GitHub Free plan — set a repo-level Actions secret named ADD_TO_PROJECT_PAT with the same PAT value."
-            exit 1
-          fi
           case "$ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR)
               echo "author=$AUTHOR association=$ASSOCIATION — adding to board"
@@ -48,41 +45,48 @@ jobs:
               exit 0
               ;;
           esac
-          headers=$(curl -s -D - -o /dev/null \
-            -H "Authorization: Bearer $PAT" \
+          response=$(mktemp)
+          trap 'rm -f "$response"' EXIT
+          if ! code=$(curl --silent --show-error \
+            --connect-timeout 10 --max-time 30 \
+            --output "$response" --write-out '%{http_code}' \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/$AUTHOR" | tr -d '\r')
-          code=$(printf '%s\n' "$headers" | head -1 | cut -d' ' -f2)
-          scopes=$(printf '%s\n' "$headers" | grep -i '^x-oauth-scopes:' | cut -d: -f2- | sed 's/^ *//')
-          echo "collaborator check: HTTP $code (PAT scopes: ${scopes:-none advertised / fine-grained})"
-          case "$code" in
-            204)
-              echo "author=$AUTHOR is a collaborator (association=$ASSOCIATION, likely private org membership) — adding to board"
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/$AUTHOR/permission"); then
+            echo "::error::Permission lookup for $AUTHOR failed at the transport layer."
+            exit 1
+          fi
+          echo "permission check: HTTP $code"
+          if [ "$code" != "200" ]; then
+            case "$code" in
+              403)
+                echo "::error::Permission lookup for $AUTHOR returned HTTP 403. Confirm the GitHub App has Metadata: Read and is approved for this installation."
+                ;;
+              404)
+                echo "::error::Permission lookup for $AUTHOR returned HTTP 404. Confirm the GitHub App is installed on $GITHUB_REPOSITORY."
+                ;;
+              *)
+                echo "::error::Permission lookup for $AUTHOR returned HTTP $code."
+                ;;
+            esac
+            exit 1
+          fi
+          if ! permission=$(jq -er '.permission | select(type == "string" and length > 0)' "$response"); then
+            echo "::error::Permission lookup for $AUTHOR returned malformed JSON or omitted permission."
+            exit 1
+          fi
+          case "$permission" in
+            admin|write)
+              echo "author=$AUTHOR permission=$permission — adding to board"
               echo "ok=true" >> "$GITHUB_OUTPUT"
               ;;
-            404)
-              # A 404 means "not a collaborator" only if the PAT can read this
-              # repo's collaborator list at all. Probe that capability directly
-              # rather than inferring it from X-OAuth-Scopes: fine-grained PATs
-              # never send that header, so scope-grepping treated every
-              # fine-grained token as blind and failed the run on every
-              # outsider-authored issue. A classic repo-scoped PAT still probes
-              # 200, so this is strictly more general than the scope check.
-              list_code=$(curl -s -o /dev/null -w '%{http_code}' \
-                -H "Authorization: Bearer $PAT" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators?per_page=1")
-              echo "collaborator-list probe: HTTP $list_code"
-              if [ "$list_code" = "200" ]; then
-                echo "author=$AUTHOR is not a collaborator — leaving for human triage"
-                echo "ok=false" >> "$GITHUB_OUTPUT"
-              else
-                echo "::error::Cannot determine whether $AUTHOR is a collaborator: the per-user check returned 404 and the collaborator-list probe returned HTTP $list_code, so ADD_TO_PROJECT_PAT cannot read this repo's collaborators. Grant it repo access (classic: repo scope; fine-grained: this repo + Metadata: Read), then re-run."
-                exit 1
-              fi
+            read|none)
+              echo "author=$AUTHOR permission=$permission — leaving for human triage"
+              echo "ok=false" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "::error::Collaborator check for $AUTHOR returned HTTP $code with the PAT."
+              echo "::error::Permission lookup for $AUTHOR returned unknown permission '$permission'."
               exit 1
               ;;
           esac
@@ -90,4 +94,4 @@ jobs:
         if: steps.gate.outputs.ok == 'true'
         with:
           project-url: https://github.com/orgs/NextCommerceCo/projects/10
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What changed

- Create a short-lived GitHub App installation token with only Metadata: Read, Issues: Read, and organization Projects: Write.
- Replace the PAT-backed two-call collaborator probe with one `GET /collaborators/{user}/permission` lookup.
- Add only authors with effective `write` or `admin` access; leave `read` and `none` authors for human triage.
- Fail closed on transport errors, non-200 responses, malformed JSON, and unknown permission values.
- Pass the same installation token to `actions/add-to-project`; the token is revoked automatically after the job.

## Why

The existing workflow depends on a long-lived user PAT and needs an extra capability probe to interpret 404 responses. The org-owned App gives this automation a repository-scoped, one-hour credential with an explicit least-privilege contract and a direct effective-permission result.

## Configuration

The App is installed on the three live workflow repositories (and `campaigns-agent` for future use). The two public repositories receive the Client ID and private key through selected organization Actions configuration. The private `next-campaigns-ops` repository uses repository-level entries with the same names because GitHub Free does not expose organization Actions configuration to private repositories.

`ADD_TO_PROJECT_PAT` remains configured as the rollback credential through the canary and 48-hour observation window.

## Validation

- `actionlint .github/workflows/add-to-project.yml`
- Extracted gate shell passes `bash -n`
- All three workflow files are byte-identical
- Acceptance matrix passes: event fast path, `write`, `admin`, `read`, `none`, HTTP 403/404/500, curl transport failure, malformed JSON, and unknown permission

## Rollout

Keep this PR in draft until coordinated rollout. Merge order:

1. `next-campaigns-ops`; run a trusted-author issue canary.
2. `campaigns-os`; repeat the trusted-author canary.
3. `campaign-cart-starter-templates`; run an outsider canary and confirm a green skip.
4. Observe for 48 hours before removing the PAT.
