### PR TITLE
fix(receipt): gate receipt surfaces on order state, not cleared cart state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,8 @@ scripts:
 | `data-next-display="cart.total"` | Renders a dynamic value |
 | `data-next-show="cart.hasDiscounts"` | Conditional visibility (0.4.x cart / receipt; prefer over legacy `cart.hasSavings`) |
 | `data-next-display="cart.originalPrice"` | **Unsupported** on `cart.*` in current `CartDisplayEnhancer` (unresolved path / no DOM update). For crossed pricing with `cart.total`, use `data-next-display="cart.subtotal"` with `data-next-show="cart.hasDiscounts"`. |
-| `data-next-hide="cart.isEmpty"` | Inverse conditional |
+| `data-next-hide="cart.isEmpty"` | Inverse conditional (checkout/upsell only — never on receipt pages, see below) |
+| `data-next-show="order.hasItems"` | **Receipt gating.** Receipt surfaces must bind to `order.*` (`order.hasItems`, `order.hasDiscounts`, `order.subtotal`, `order.total`), never `cart.*`: SDK ≥0.4.17 clears cart/coupon session state before the post-checkout redirect, so `cart.isEmpty` is always true on the receipt and a cart-gated wrapper hides the populated `data-next-order-items` list. `order.hasItems`/`order.isEmpty` are source-verified in `ConditionalDisplayEnhancer` of the pinned SDK (v0.4.30) even though the typedoc attribute index doesn't enumerate condition paths. The order-item-list enhancer is self-contained (its own `order-loading`/`order-has-items`/`order-empty`/`order-error` classes + `data-empty-template`) — no wrapper is load-bearing for it. |
 | `data-next-cart-summary` + `data-summary-lines` | Cart summary v2 (0.4.x); replaces legacy `data-next-cart-items` |
 | `data-next-bump` | Order bump toggle |
 | `data-next-express-checkout="container"` | Express checkout (PayPal/Apple/Google Pay) |

--- a/docs/campaign-page-kit-template-context.md
+++ b/docs/campaign-page-kit-template-context.md
@@ -646,6 +646,8 @@ bundles:
 
 `cart.hasCoupon()` (SDK 0.4.20+): truthy when any coupon is applied. `cart.hasCoupon("CODE")` matches a specific code (case-insensitive, quotes stripped). Use to show banners or messaging only when a coupon is active.
 
+**Receipt pages must bind to `order.*`, never `cart.*`.** SDK ≥0.4.17 clears cart and coupon session state before the post-checkout redirect, so on a receipt page `cart.isEmpty` is always true and `cart.hasItems`/`cart.total` are always empty — a cart-gated element hides or blanks a correctly loaded order. Use `data-next-show="order.hasItems"` / `order.hasDiscounts` and `data-next-display="order.subtotal"` / `order.total` instead (the order-item-list enhancer also exposes `order-loading` / `order-has-items` / `order-empty` / `order-error` state classes and `data-empty-template` for finer control).
+
 ### Cart item list
 
 ```html

--- a/src/apollo-mv-single-step/_includes/receipt-orders.html
+++ b/src/apollo-mv-single-step/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/apollo-mv-single-step/_includes/receipt-orders.html
+++ b/src/apollo-mv-single-step/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/apollo-mv-single-step/receipt.html
+++ b/src/apollo-mv-single-step/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>

--- a/src/apollo/_includes/receipt-orders.html
+++ b/src/apollo/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/apollo/_includes/receipt-orders.html
+++ b/src/apollo/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/apollo/receipt.html
+++ b/src/apollo/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>

--- a/src/demeter/_includes/receipt-order-summary-desktop.html
+++ b/src/demeter/_includes/receipt-order-summary-desktop.html
@@ -26,7 +26,7 @@
                                     <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
                                   </svg></div>
                               </div>
-                              <div data-next-hide="cart.isEmpty"><template id="{{ tpl_id }}" class="item-template os-show">
+                              <div data-next-show="order.hasItems"><template id="{{ tpl_id }}" class="item-template os-show">
                                   <div data-order-line-id="{item.id}" class="cart-item">
                                     <div class="cart-item__wrapper">
                                       <div class="cart-item__image-container">

--- a/src/demeter/_includes/receipt-order-summary-mobile.html
+++ b/src/demeter/_includes/receipt-order-summary-mobile.html
@@ -21,9 +21,9 @@
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>
@@ -38,7 +38,7 @@
                                     <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
                                   </svg></div>
                               </div>
-                              <div data-next-hide="cart.isEmpty"><template id="{{ tpl_id }}" class="item-template os-show">
+                              <div data-next-show="order.hasItems"><template id="{{ tpl_id }}" class="item-template os-show">
                                   <div data-order-line-id="{item.id}" class="cart-item">
                                     <div class="cart-item__wrapper">
                                       <div class="cart-item__image-container">

--- a/src/olympus-mv-single-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-single-step/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/olympus-mv-single-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-single-step/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/olympus-mv-single-step/receipt.html
+++ b/src/olympus-mv-single-step/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>

--- a/src/olympus-mv-two-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-two-step/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/olympus-mv-two-step/_includes/receipt-orders.html
+++ b/src/olympus-mv-two-step/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/olympus-mv-two-step/receipt.html
+++ b/src/olympus-mv-two-step/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>

--- a/src/olympus/_includes/receipt-orders.html
+++ b/src/olympus/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/olympus/_includes/receipt-orders.html
+++ b/src/olympus/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/olympus/receipt.html
+++ b/src/olympus/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>

--- a/src/shop-single-step/_includes/receipt-order-summary-desktop.html
+++ b/src/shop-single-step/_includes/receipt-order-summary-desktop.html
@@ -26,7 +26,7 @@
                                     <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
                                   </svg></div>
                               </div>
-                              <div data-next-hide="cart.isEmpty"><template id="{{ tpl_id }}" class="item-template os-show">
+                              <div data-next-show="order.hasItems"><template id="{{ tpl_id }}" class="item-template os-show">
                                   <div data-order-line-id="{item.id}" class="cart-item">
                                     <div class="cart-item__wrapper">
                                       <div class="cart-item__image-container">

--- a/src/shop-single-step/_includes/receipt-order-summary-mobile.html
+++ b/src/shop-single-step/_includes/receipt-order-summary-mobile.html
@@ -21,9 +21,9 @@
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>
@@ -38,7 +38,7 @@
                                     <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
                                   </svg></div>
                               </div>
-                              <div data-next-hide="cart.isEmpty"><template id="{{ tpl_id }}" class="item-template os-show">
+                              <div data-next-show="order.hasItems"><template id="{{ tpl_id }}" class="item-template os-show">
                                   <div data-order-line-id="{item.id}" class="cart-item">
                                     <div class="cart-item__wrapper">
                                       <div class="cart-item__image-container">

--- a/src/shop-three-step/_includes/receipt-orders.html
+++ b/src/shop-three-step/_includes/receipt-orders.html
@@ -1,7 +1,7 @@
 {% comment %}
   next_component: receipt-orders
   next_version: 1.0.1
-  next_sdk_min: 0.4.18
+  next_sdk_min: 0.4.18 (order.* condition paths incl. order.hasItems source-verified in ConditionalDisplayEnhancer at v0.4.18 and unchanged through v0.4.33)
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:

--- a/src/shop-three-step/_includes/receipt-orders.html
+++ b/src/shop-three-step/_includes/receipt-orders.html
@@ -1,13 +1,13 @@
 {% comment %}
   next_component: receipt-orders
-  next_version: 1.0.0
+  next_version: 1.0.1
   next_sdk_min: 0.4.18
   next_purpose: Receipt page order line items. Hosts the SDK template + list for rendering ordered items after payment. SDK populates [data-next-order-items] from OrderItemsEnhancer.
   next_params: (none today; parameterization deferred to v1 if cart-item template variants emerge across receipts)
   next_sdk_owns:
     - data-next-order-items
     - data-item-template-id (must match the inner <template id>)
-    - data-next-hide="cart.isEmpty"
+    - data-next-show="order.hasItems"
     - data-next-quantity (decrease/increase) inside template (currently hidden but kept for symmetry with cart-item markup)
     - Single-brace tokens inside <template> are SDK syntax, not Liquid: {item.id}, {item.image}, {item.quantity}, {item.name}, {item.packageId}, {item.lineTotal}
   next_theming:
@@ -16,7 +16,8 @@
   next_dont_touch:
     - Do not change single-brace tokens to Liquid {{ }} — SDK templating, not Liquid
     - data-item-template-id on the list MUST match the <template id> exactly ("order-item-template")
-    - Do not remove data-next-hide="cart.isEmpty" wrapper — SDK relies on it for empty-state suppression
+    - Do not remove the data-next-show="order.hasItems" wrapper — it suppresses the empty-state box until the order loads with items
+    - Never gate receipt visibility on cart.* state: SDK >=0.4.17 clears cart/coupon session state before the post-checkout redirect, so cart.isEmpty is always true on the receipt and a cart-gated wrapper hides the populated order-items list
   next_gotchas:
     - This partial is rendered twice per receipt page (desktop summary + mobile summary). Keep both invocations identical
   next_variants:
@@ -32,7 +33,7 @@
         <path fill="currentColor" d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6l-6-6z"></path>
       </svg></div>
   </div>
-  <div data-next-hide="cart.isEmpty"><template id="order-item-template" class="item-template os-show">
+  <div data-next-show="order.hasItems"><template id="order-item-template" class="item-template os-show">
       <div data-order-line-id="{item.id}" class="cart-item">
         <div class="cart-item__wrapper">
           <div class="cart-item__image-container">

--- a/src/shop-three-step/receipt.html
+++ b/src/shop-three-step/receipt.html
@@ -22,9 +22,9 @@ styles:
                               <div data-next-accordion-text="order-summary" class="summary-toggle__text show_text">Show Order Summary</div><img os-summary-icon="" loading="lazy" alt="" src="{{ 'images/arrow-down.svg' | campaign_asset }}" class="summary-toggle__icon">
                             </div>
                           </div>
-                          <div data-next-show="cart.hasItems" class="order-summary__mobile-right">
-                            <div data-next-show="cart.hasDiscounts" data-next-display="cart.subtotal" class="summary_price price--crossed cc-sm"></div>
-                            <div data-next-display="cart.total" class="summary_price price--total"></div>
+                          <div data-next-show="order.hasItems" class="order-summary__mobile-right">
+                            <div data-next-show="order.hasDiscounts" data-next-display="order.subtotal" class="summary_price price--crossed cc-sm"></div>
+                            <div data-next-display="order.total" class="summary_price price--total"></div>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Problem

The certified `receipt-orders.html` partial (all 6 copies) wraps the SDK `data-next-order-items` list in `data-next-hide="cart.isEmpty"`, and every receipt page's mobile accordion header binds `cart.hasItems` / `cart.hasDiscounts` / `cart.subtotal` / `cart.total`. But campaign-cart SDK ≥0.4.17 resets cart + coupon session state before the post-checkout redirect (`checkout-form.enhancer.ts` success paths, express checkout included), so on a receipt page `cart.isEmpty` is always **true** — the wrapper hides a correctly populated order-items list, and the mobile header prices never render.

## Verdict on the certified header's claim

The partial's `next_dont_touch` said the wrapper is SDK-load-bearing ("SDK relies on it for empty-state suppression"). **Source-verified false** against the pinned SDK v0.4.30: `OrderItemListEnhancer` is fully self-contained — it targets `[data-next-order-items]`, manages its own `order-loading` / `order-has-items` / `order-empty` / `order-error` state classes and `data-empty-template`, and references no wrapper. The certified partial was defective for every receipt built from it.

Also corrected a premise from the migration cell: `data-next-show="order.hasItems"` **does exist** in the 0.4.x SDK — `ConditionalDisplayEnhancer` supports `order.hasItems` / `order.isEmpty` / `order.hasDiscounts` as condition paths with an order-store subscription (v0.4.30 source ~line 1583; also present in 0.4.32's `conditional-display.order-properties.ts`). The typedoc attribute index doesn't enumerate condition paths, hence the zero hits. The templates already use `order.hasTax` the same way.

## Changes

- `receipt-orders.html` ×6 (apollo, apollo-mv-single-step, olympus, olympus-mv-single-step, olympus-mv-two-step, shop-three-step): wrapper → `data-next-show="order.hasItems"`; certified header bumped to 1.0.1 with corrected `next_sdk_owns` / `next_dont_touch` and a never-gate-receipt-on-cart gotcha. All six copies stay byte-identical.
- `receipt-order-summary-{desktop,mobile}.html` (demeter, shop-single-step): same wrapper swap; mobile header `cart.*` → `order.*`.
- `receipt.html` ×6: mobile accordion header → `order.hasItems` / `order.hasDiscounts` / `order.subtotal` / `order.total`.
- `CLAUDE.md` + `docs/campaign-page-kit-template-context.md`: documented the receipt-binds-to-order rule (matches next-mind sdk04x-migration gotcha).

## Verification

- `npm run lint:sdk`, `lint:sdk:ci` (--pages=all), `lint:next-core`, `lint:shared` — all PASS (HTML partials aren't byte-parity-gated; the order-items include stays catalog-wrapped).
- `npm run build` — 66 pages; built receipts carry 3× `order.hasItems` each and zero `cart.*` bindings.

Surfaced during the bladdersupport SDK-0.4.32 migration cell (equivalence ledger open decision 9, worktree `primalnutrients--bladdersupport-uplift`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)