### PR TITLE
fix(bump-check01): parameterize package/sync ids in mv/shop variants

### DIFF
--- a/src/apollo-mv-single-step/_includes/bump-check01.html
+++ b/src/apollo-mv-single-step/_includes/bump-check01.html
@@ -1,34 +1,39 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
+    package_id: number, default 77 (demo add-on). data-next-package-id (the bump's package). Also settable via order_bump.check01.package_id.
+    product_sync: number|false, default 400 (demo "T Shirt" product_id). data-next-product-sync — sums qty across every variant of the product (see comment below). Set false to disable sync. Also settable via order_bump.check01.product_sync.
     show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
+{% assign bump = order_bump.check01 -%}
+{% assign pkg_id = package_id | default: bump.package_id | default: 77 -%}
+{% if product_sync != nil %}{% assign b_sync = product_sync %}{% elsif bump.product_sync != nil %}{% assign b_sync = bump.product_sync %}{% else %}{% assign b_sync = 400 %}{% endif -%}
 {% if show_per_unit_price != nil %}{% assign b_unit = show_per_unit_price %}{% elsif bump.show_per_unit_price != nil %}{% assign b_unit = bump.show_per_unit_price %}{% else %}{% assign b_unit = true %}{% endif -%}
 {% if show_compare_price != nil %}{% assign b_compare = show_compare_price %}{% elsif bump.show_compare_price != nil %}{% assign b_compare = bump.show_compare_price %}{% else %}{% assign b_compare = false %}{% endif -%}
 {% if show_line_total_price != nil %}{% assign b_line_total = show_line_total_price %}{% elsif bump.show_line_total_price != nil %}{% assign b_line_total = bump.show_line_total_price %}{% else %}{% assign b_line_total = false %}{% endif -%}
-{% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign feature_list = features | default: bump.features -%}
-<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+{% comment %} Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
      Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+       To switch: pass show_per_unit_price=false show_line_total_price=true to the campaign_include {% endcomment -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
+    {% comment %} QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
          data-next-package-sync matches cart lines by packageId, which under-counts on a configurable
          MV bundle: each variant (color/size) is its own package, and on variant swap the SDK rebuilds
          the line under the new variant's packageId. data-next-product-sync matches by product_id instead,
          which every variant of a product shares, so one id sums quantity across all variants — present
          and future. 400 is this demo campaign's "T Shirt" product_id (verified: variant ref_ids 1-9 and
-         66-74 all return product_id 400). Replace with your product's id when cloning — find it under
-         packages[].product_id in the campaign API response (same value for every variant). -->
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-product-sync="400" data-next-package-id="77">
-      <!-- Bump header — visual only, whole card is the toggle target -->
+         66-74 all return product_id 400). When cloning, set order_bump.check01.product_sync (and
+         .package_id) in the page frontmatter — no need to edit this partial. Find the id under
+         packages[].product_id in the campaign API response (same value for every variant). {% endcomment -%}
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true"{% if b_sync %} data-next-product-sync="{{ b_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">
+      {% comment %} Bump header — visual only, whole card is the toggle target {% endcomment -%}
       <div class="bump__header-left">
         <div class="bump__header-content">
           <div class="bump__checkbox">
@@ -37,20 +42,20 @@
           <div class="bump__title">{{ t }}</div>
         </div>
       </div>
-      <!-- Bump body: price, list, image -->
+      {% comment %} Bump body: price, list, image {% endcomment -%}
       <div class="bump__body">
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
               {% if b_unit %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              {% comment %} Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) {% endcomment -%}
               <div class="bump__price-row">
                 {% if b_compare %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if b_line_total %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              {% comment %} Option B: line total pricing — scales with synced qty {% endcomment -%}
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>

--- a/src/apollo-mv-single-step/checkout.html
+++ b/src/apollo-mv-single-step/checkout.html
@@ -97,7 +97,10 @@ packages:
 order_bump:
   check01:
     # Pre-purchase add-on (checkbox card). Optional keys (full list: _includes/bump-check01.html):
-    #   sync_quantity: <main packageId>    -> add-on qty mirrors the main bundle (omit = fixed qty 1)
+    #   package_id: <packageId>            -> the add-on package this bump adds (default 77, the demo add-on)
+    #   product_sync: <product_id>|false   -> add-on qty mirrors the main product across ALL its variants, matched by
+    #                                         product_id (default 400, the demo "T Shirt"; false = fixed qty 1).
+    #                                         MV mains need product_sync, not packageId sync — see _includes/bump-check01.html
     #   show_per_unit_price:   true|false  -> per-unit "$X/ea" row, stable across qty (default true)
     #   show_compare_price:    true|false  -> struck originalUnitPrice beside it (default false)
     #   show_line_total_price: true|false  -> line totals instead (scales with qty); pick this OR per-unit

--- a/src/olympus-mv-single-step/_includes/bump-check01.html
+++ b/src/olympus-mv-single-step/_includes/bump-check01.html
@@ -1,34 +1,39 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
+    package_id: number, default 77 (demo add-on). data-next-package-id (the bump's package). Also settable via order_bump.check01.package_id.
+    product_sync: number|false, default 400 (demo "T Shirt" product_id). data-next-product-sync — sums qty across every variant of the product (see comment below). Set false to disable sync. Also settable via order_bump.check01.product_sync.
     show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
+{% assign bump = order_bump.check01 -%}
+{% assign pkg_id = package_id | default: bump.package_id | default: 77 -%}
+{% if product_sync != nil %}{% assign b_sync = product_sync %}{% elsif bump.product_sync != nil %}{% assign b_sync = bump.product_sync %}{% else %}{% assign b_sync = 400 %}{% endif -%}
 {% if show_per_unit_price != nil %}{% assign b_unit = show_per_unit_price %}{% elsif bump.show_per_unit_price != nil %}{% assign b_unit = bump.show_per_unit_price %}{% else %}{% assign b_unit = true %}{% endif -%}
 {% if show_compare_price != nil %}{% assign b_compare = show_compare_price %}{% elsif bump.show_compare_price != nil %}{% assign b_compare = bump.show_compare_price %}{% else %}{% assign b_compare = false %}{% endif -%}
 {% if show_line_total_price != nil %}{% assign b_line_total = show_line_total_price %}{% elsif bump.show_line_total_price != nil %}{% assign b_line_total = bump.show_line_total_price %}{% else %}{% assign b_line_total = false %}{% endif -%}
-{% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign feature_list = features | default: bump.features -%}
-<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+{% comment %} Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
      Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+       To switch: pass show_per_unit_price=false show_line_total_price=true to the campaign_include {% endcomment -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
+    {% comment %} QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
          data-next-package-sync matches cart lines by packageId, which under-counts on a configurable
          MV bundle: each variant (color/size) is its own package, and on variant swap the SDK rebuilds
          the line under the new variant's packageId. data-next-product-sync matches by product_id instead,
          which every variant of a product shares, so one id sums quantity across all variants — present
          and future. 400 is this demo campaign's "T Shirt" product_id (verified: variant ref_ids 1-9 and
-         66-74 all return product_id 400). Replace with your product's id when cloning — find it under
-         packages[].product_id in the campaign API response (same value for every variant). -->
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-product-sync="400" data-next-package-id="77">
-      <!-- Bump header — visual only, whole card is the toggle target -->
+         66-74 all return product_id 400). When cloning, set order_bump.check01.product_sync (and
+         .package_id) in the page frontmatter — no need to edit this partial. Find the id under
+         packages[].product_id in the campaign API response (same value for every variant). {% endcomment -%}
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true"{% if b_sync %} data-next-product-sync="{{ b_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">
+      {% comment %} Bump header — visual only, whole card is the toggle target {% endcomment -%}
       <div class="bump__header-left">
         <div class="bump__header-content">
           <div class="bump__checkbox">
@@ -37,20 +42,20 @@
           <div class="bump__title">{{ t }}</div>
         </div>
       </div>
-      <!-- Bump body: price, list, image -->
+      {% comment %} Bump body: price, list, image {% endcomment -%}
       <div class="bump__body">
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
               {% if b_unit %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              {% comment %} Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) {% endcomment -%}
               <div class="bump__price-row">
                 {% if b_compare %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if b_line_total %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              {% comment %} Option B: line total pricing — scales with synced qty {% endcomment -%}
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>

--- a/src/olympus-mv-single-step/checkout.html
+++ b/src/olympus-mv-single-step/checkout.html
@@ -6,7 +6,10 @@ promo_sale: "default"
 order_bump:
   check01:
     # Pre-purchase add-on (checkbox card). Optional keys (full list: _includes/bump-check01.html):
-    #   sync_quantity: <main packageId>    -> add-on qty mirrors the main bundle (omit = fixed qty 1)
+    #   package_id: <packageId>            -> the add-on package this bump adds (default 77, the demo add-on)
+    #   product_sync: <product_id>|false   -> add-on qty mirrors the main product across ALL its variants, matched by
+    #                                         product_id (default 400, the demo "T Shirt"; false = fixed qty 1).
+    #                                         MV mains need product_sync, not packageId sync — see _includes/bump-check01.html
     #   show_per_unit_price:   true|false  -> per-unit "$X/ea" row, stable across qty (default true)
     #   show_compare_price:    true|false  -> struck originalUnitPrice beside it (default false)
     #   show_line_total_price: true|false  -> line totals instead (scales with qty); pick this OR per-unit

--- a/src/olympus-mv-two-step/_includes/bump-check01.html
+++ b/src/olympus-mv-two-step/_includes/bump-check01.html
@@ -1,34 +1,39 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
+    package_id: number, default 77 (demo add-on). data-next-package-id (the bump's package). Also settable via order_bump.check01.package_id.
+    product_sync: number|false, default 400 (demo "T Shirt" product_id). data-next-product-sync — sums qty across every variant of the product (see comment below). Set false to disable sync. Also settable via order_bump.check01.product_sync.
     show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
+{% assign bump = order_bump.check01 -%}
+{% assign pkg_id = package_id | default: bump.package_id | default: 77 -%}
+{% if product_sync != nil %}{% assign b_sync = product_sync %}{% elsif bump.product_sync != nil %}{% assign b_sync = bump.product_sync %}{% else %}{% assign b_sync = 400 %}{% endif -%}
 {% if show_per_unit_price != nil %}{% assign b_unit = show_per_unit_price %}{% elsif bump.show_per_unit_price != nil %}{% assign b_unit = bump.show_per_unit_price %}{% else %}{% assign b_unit = true %}{% endif -%}
 {% if show_compare_price != nil %}{% assign b_compare = show_compare_price %}{% elsif bump.show_compare_price != nil %}{% assign b_compare = bump.show_compare_price %}{% else %}{% assign b_compare = false %}{% endif -%}
 {% if show_line_total_price != nil %}{% assign b_line_total = show_line_total_price %}{% elsif bump.show_line_total_price != nil %}{% assign b_line_total = bump.show_line_total_price %}{% else %}{% assign b_line_total = false %}{% endif -%}
-{% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign feature_list = features | default: bump.features -%}
-<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+{% comment %} Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
      Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+       To switch: pass show_per_unit_price=false show_line_total_price=true to the campaign_include {% endcomment -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <!-- QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
+    {% comment %} QTY SYNC ON MV / CONFIGURABLE PRODUCTS — data-next-product-sync (SDK 0.4.25+).
          data-next-package-sync matches cart lines by packageId, which under-counts on a configurable
          MV bundle: each variant (color/size) is its own package, and on variant swap the SDK rebuilds
          the line under the new variant's packageId. data-next-product-sync matches by product_id instead,
          which every variant of a product shares, so one id sums quantity across all variants — present
          and future. 400 is this demo campaign's "T Shirt" product_id (verified: variant ref_ids 1-9 and
-         66-74 all return product_id 400). Replace with your product's id when cloning — find it under
-         packages[].product_id in the campaign API response (same value for every variant). -->
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-product-sync="400" data-next-package-id="77">
-      <!-- Bump header — visual only, whole card is the toggle target -->
+         66-74 all return product_id 400). When cloning, set order_bump.check01.product_sync (and
+         .package_id) in the page frontmatter — no need to edit this partial. Find the id under
+         packages[].product_id in the campaign API response (same value for every variant). {% endcomment -%}
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true"{% if b_sync %} data-next-product-sync="{{ b_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">
+      {% comment %} Bump header — visual only, whole card is the toggle target {% endcomment -%}
       <div class="bump__header-left">
         <div class="bump__header-content">
           <div class="bump__checkbox">
@@ -37,20 +42,20 @@
           <div class="bump__title">{{ t }}</div>
         </div>
       </div>
-      <!-- Bump body: price, list, image -->
+      {% comment %} Bump body: price, list, image {% endcomment -%}
       <div class="bump__body">
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
               {% if b_unit %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              {% comment %} Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) {% endcomment -%}
               <div class="bump__price-row">
                 {% if b_compare %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if b_line_total %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              {% comment %} Option B: line total pricing — scales with synced qty {% endcomment -%}
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>

--- a/src/olympus-mv-two-step/checkout.html
+++ b/src/olympus-mv-two-step/checkout.html
@@ -6,7 +6,10 @@ promo_sale: "default"
 order_bump:
   check01:
     # Pre-purchase add-on (checkbox card). Optional keys (full list: _includes/bump-check01.html):
-    #   sync_quantity: <main packageId>    -> add-on qty mirrors the main bundle (omit = fixed qty 1)
+    #   package_id: <packageId>            -> the add-on package this bump adds (default 77, the demo add-on)
+    #   product_sync: <product_id>|false   -> add-on qty mirrors the main product across ALL its variants, matched by
+    #                                         product_id (default 400, the demo "T Shirt"; false = fixed qty 1).
+    #                                         MV mains need product_sync, not packageId sync — see _includes/bump-check01.html
     #   show_per_unit_price:   true|false  -> per-unit "$X/ea" row, stable across qty (default true)
     #   show_compare_price:    true|false  -> struck originalUnitPrice beside it (default false)
     #   show_line_total_price: true|false  -> line totals instead (scales with qty); pick this OR per-unit

--- a/src/shop-single-step/_includes/bump-check01.html
+++ b/src/shop-single-step/_includes/bump-check01.html
@@ -1,26 +1,30 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
+    package_id: number, default 7 (demo add-on). data-next-package-id (the bump's package). Also settable via order_bump.check01.package_id.
+    package_sync: number|false, default 1. data-next-package-sync (mirrors main bundle qty, matched by packageId). Set false to disable sync. Also settable via order_bump.check01.sync_quantity.
     show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
+{% assign bump = order_bump.check01 -%}
+{% assign pkg_id = package_id | default: bump.package_id | default: 7 -%}
+{% if package_sync != nil %}{% assign b_sync = package_sync %}{% elsif bump.sync_quantity != nil %}{% assign b_sync = bump.sync_quantity %}{% else %}{% assign b_sync = 1 %}{% endif -%}
 {% if show_per_unit_price != nil %}{% assign b_unit = show_per_unit_price %}{% elsif bump.show_per_unit_price != nil %}{% assign b_unit = bump.show_per_unit_price %}{% else %}{% assign b_unit = true %}{% endif -%}
 {% if show_compare_price != nil %}{% assign b_compare = show_compare_price %}{% elsif bump.show_compare_price != nil %}{% assign b_compare = bump.show_compare_price %}{% else %}{% assign b_compare = false %}{% endif -%}
 {% if show_line_total_price != nil %}{% assign b_line_total = show_line_total_price %}{% elsif bump.show_line_total_price != nil %}{% assign b_line_total = bump.show_line_total_price %}{% else %}{% assign b_line_total = false %}{% endif -%}
-{% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign feature_list = features | default: bump.features -%}
-<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+{% comment %} Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
      Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+       To switch: pass show_per_unit_price=false show_line_total_price=true to the campaign_include {% endcomment -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
-      <!-- Bump header — visual only, whole card is the toggle target -->
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true"{% if b_sync %} data-next-package-sync="{{ b_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">
+      {% comment %} Bump header — visual only, whole card is the toggle target {% endcomment -%}
       <div class="bump__header-left">
         <div class="bump__header-content">
           <div class="bump__checkbox">
@@ -29,20 +33,20 @@
           <div class="bump__title">{{ t }}</div>
         </div>
       </div>
-      <!-- Bump body: price, list, image -->
+      {% comment %} Bump body: price, list, image {% endcomment -%}
       <div class="bump__body">
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
               {% if b_unit %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              {% comment %} Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) {% endcomment -%}
               <div class="bump__price-row">
                 {% if b_compare %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if b_line_total %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              {% comment %} Option B: line total pricing — scales with synced qty {% endcomment -%}
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>

--- a/src/shop-three-step/_includes/bump-check01.html
+++ b/src/shop-three-step/_includes/bump-check01.html
@@ -1,26 +1,30 @@
 {% comment %}
   next_component: order-bump-card
   next_params:
+    package_id: number, default 7 (demo add-on). data-next-package-id (the bump's package). Also settable via order_bump.check01.package_id.
+    package_sync: number|false, default 1. data-next-package-sync (mirrors main bundle qty, matched by packageId). Set false to disable sync. Also settable via order_bump.check01.sync_quantity.
     show_compare_price: bool, default false. Explicitly render struck originalUnitPrice in Option A.
     show_per_unit_price: bool, default true. Render Option A row (unitPrice/ea).
     show_line_total_price: bool, default false. Render Option B row (originalPrice + price).
 {% endcomment %}
+{% assign bump = order_bump.check01 -%}
+{% assign pkg_id = package_id | default: bump.package_id | default: 7 -%}
+{% if package_sync != nil %}{% assign b_sync = package_sync %}{% elsif bump.sync_quantity != nil %}{% assign b_sync = bump.sync_quantity %}{% else %}{% assign b_sync = 1 %}{% endif -%}
 {% if show_per_unit_price != nil %}{% assign b_unit = show_per_unit_price %}{% elsif bump.show_per_unit_price != nil %}{% assign b_unit = bump.show_per_unit_price %}{% else %}{% assign b_unit = true %}{% endif -%}
 {% if show_compare_price != nil %}{% assign b_compare = show_compare_price %}{% elsif bump.show_compare_price != nil %}{% assign b_compare = bump.show_compare_price %}{% else %}{% assign b_compare = false %}{% endif -%}
 {% if show_line_total_price != nil %}{% assign b_line_total = show_line_total_price %}{% elsif bump.show_line_total_price != nil %}{% assign b_line_total = bump.show_line_total_price %}{% else %}{% assign b_line_total = false %}{% endif -%}
-{% assign bump = order_bump.check01 -%}
 {% assign t = bump_title | default: bump.title | default: 'Order Bump Title' -%}
 {% assign feature_list = features | default: bump.features -%}
-<!-- Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
+{% comment %} Prepurchase upsell: checkbox bump (check01) — SDK 0.4.x
      Uses data-next-package-toggle / data-next-toggle-card / data-next-toggle-display
      Pick ONE pricing row — rendering both confuses the customer.
      Option A (per-unit, stable, DEFAULT): unitPrice/ea, with originalUnitPrice/ea only when show_compare_price=true — does not scale with synced qty
      Option B (line total, scales, opt-in): originalPrice + price — multiplies with data-next-package-sync qty
-       To switch: pass show_per_unit_price=false show_line_total_price=true to {% campaign_include %} -->
+       To switch: pass show_per_unit_price=false show_line_total_price=true to the campaign_include {% endcomment -%}
 <div data-next-catalog-component="order-bump-card" data-component="prepurchase-upsell" data-variant="check01" data-next-await="">
   <div data-next-package-toggle>
-    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true" data-next-package-sync="1" data-next-package-id="7">
-      <!-- Bump header — visual only, whole card is the toggle target -->
+    <div class="bump-card" data-next-toggle-card data-next-is-upsell="true"{% if b_sync %} data-next-package-sync="{{ b_sync }}"{% endif %} data-next-package-id="{{ pkg_id }}">
+      {% comment %} Bump header — visual only, whole card is the toggle target {% endcomment -%}
       <div class="bump__header-left">
         <div class="bump__header-content">
           <div class="bump__checkbox">
@@ -29,20 +33,20 @@
           <div class="bump__title">{{ t }}</div>
         </div>
       </div>
-      <!-- Bump body: price, list, image -->
+      {% comment %} Bump body: price, list, image {% endcomment -%}
       <div class="bump__body">
         <div class="bump__content">
           <div class="bump__content-wrap">
             <div class="bump__price">
               {% if b_unit %}
-              <!-- Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) -->
+              {% comment %} Option A: per-unit pricing — stable across tier changes (SDK 0.4.14+) {% endcomment -%}
               <div class="bump__price-row">
                 {% if b_compare %}<div class="bump__price-unit"><span data-next-toggle-display="originalUnitPrice" class="bump__price-reg">--</span></div>{% endif %}
                 <div class="bump__price-unit"><span data-next-toggle-display="unitPrice" class="bump__price-sale">--</span><span class="text-xl">/ea</span></div>
               </div>
               {% endif %}
               {% if b_line_total %}
-              <!-- Option B: line total pricing — scales with synced qty -->
+              {% comment %} Option B: line total pricing — scales with synced qty {% endcomment -%}
               <div class="bump__price-row">
                 <div data-next-toggle-display="originalPrice" class="bump__price-reg">--</div>
                 <div data-next-toggle-display="price" class="bump__price-total">--</div>


### PR DESCRIPTION
Closes #78

## What

Parameterizes the hardcoded package/sync ids in the five `bump-check01.html` partials that still had them, matching the olympus/apollo pattern:

| Variant | Wiring |
|---|---|
| `apollo-mv-single-step`, `olympus-mv-single-step`, `olympus-mv-two-step` | `data-next-package-id` + `data-next-product-sync` from include args or `order_bump.check01.package_id` / `.product_sync`, defaults 77 / 400 (demo). `product_sync: false` drops the sync attribute |
| `shop-single-step`, `shop-three-step` | `data-next-package-id` + `data-next-package-sync` from `package_id` / `sync_quantity` (olympus key names), defaults 7 / 1 |

Since #78 was filed, `apollo-mv-single-step` inherited the hardcoded MV variant, so this covers five families (the issue listed four).

## Also in this PR

- **Include-scope leak fix:** these partials evaluated their price flags *before* assigning `bump`, so they read a sibling partial's leaked `bump` variable. On the apollo-mv demo checkout, check01 was rendering a struck compare price it was never configured for — picked up from **check03's** `show_compare_price: true` frontmatter. Assigns now run first (same ordering as olympus). Same leak class as the bump-title leak fixed previously.
- **Liquid comments:** instructional HTML comments in these five partials converted to `{% comment %}` so they don't ship in rendered HTML (the QTY SYNC explainer alone was ~9 lines in every MV checkout page).

## Verification

- Full-site diff against a baseline build: default demo output unchanged apart from comment removals and the leak fix (rendered output only *removes* lines, adds none)
- Override paths tested: `package_id: 42` + `sync_quantity: 3` → `data-next-package-sync="3" data-next-package-id="42"`; `product_sync: false` → sync attribute omitted
- `lint:next-core`, `lint:shared`, `lint:sdk:ci` all pass; MV trio and shop pair remain byte-identical within their groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)