### PR TITLE
Guard SDK template tokens before hydration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@tailwindcss/cli": "^4.2.4",
+        "parse5": "7.3.0",
         "tailwindcss": "^4.2.4"
       }
     },
@@ -1307,6 +1308,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1875,6 +1889,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "compress": "npx campaign-compress",
     "compress:preview": "npx campaign-compress --preview",
     "lint:sdk": "node scripts/lint-sdk.mjs",
+    "test:sdk-template-tokens": "node --test scripts/sdk-template-token-lint.test.mjs",
     "lint:sdk:source": "node scripts/lint-sdk.mjs --source",
     "lint:sdk:rendered": "node scripts/lint-sdk.mjs --rendered",
     "lint:sdk:promoted": "node scripts/lint-sdk.mjs --scope=promoted --pages=checkout,select,upsell-bundle-stepper,upsell-bundle-tier-pills,upsell-bundle-tier-cards,upsell-mv",
     "lint:sdk:promoted:source": "node scripts/lint-sdk.mjs --source --scope=promoted --pages=checkout,select,upsell-bundle-stepper,upsell-bundle-tier-pills,upsell-bundle-tier-cards,upsell-mv",
     "lint:sdk:promoted:rendered": "node scripts/lint-sdk.mjs --rendered --scope=promoted --pages=checkout,select,upsell-bundle-stepper,upsell-bundle-tier-pills,upsell-bundle-tier-cards,upsell-mv",
     "lint:sdk:shop-single-step:all": "node scripts/lint-sdk.mjs --scope=shop-single-step --pages=all",
-    "lint:sdk:ci": "CI=1 node scripts/lint-sdk.mjs --scope=all --pages=all",
+    "lint:sdk:ci": "npm run test:sdk-template-tokens && CI=1 node scripts/lint-sdk.mjs --scope=all --pages=all",
     "lint:sdk:promoted:all": "node scripts/lint-sdk.mjs --scope=promoted --pages=all",
     "lint:next-core": "node scripts/lint-next-core-sync.mjs",
     "lint:next-logo": "node scripts/lint-next-logo-sync.mjs",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.2.4",
+    "parse5": "7.3.0",
     "tailwindcss": "^4.2.4"
   }
 }

--- a/scripts/lib/sdk-template-token-lint.mjs
+++ b/scripts/lib/sdk-template-token-lint.mjs
@@ -1,0 +1,56 @@
+import { parse } from 'parse5';
+
+const SDK_TEMPLATE_TOKEN_SOURCE = String.raw`\{(?:(?:item|line|discount|property)\.[A-Za-z0-9_]+|subtotal|total|shipping|shippingName|shippingCode|shippingOriginal|shippingDiscountAmount|shippingDiscountPercentage|totalDiscount|totalDiscountPercentage|discounts|currency|isCalculating|isEmpty|itemCount|totalQuantity|isFreeShipping|hasShippingDiscount|hasDiscounts|tax)\}`;
+
+function preserveLines(match) {
+  return '\n'.repeat(match.split('\n').length - 1);
+}
+
+function blankLiquidComments(content) {
+  return content.replace(
+    /\{%\s*comment\s*%\}[\s\S]*?\{%\s*endcomment\s*%\}/gi,
+    preserveLines,
+  );
+}
+
+function tokensIn(value) {
+  return [...value.matchAll(new RegExp(SDK_TEMPLATE_TOKEN_SOURCE, 'gi'))];
+}
+
+export function findLiveSdkTemplateTokens(content) {
+  const source = blankLiquidComments(content);
+  const document = parse(source, { sourceCodeLocationInfo: true });
+  const violations = [];
+
+  function visit(node) {
+    if (node.tagName === 'template' || node.tagName === 'script' || node.tagName === 'style') {
+      return;
+    }
+
+    if (node.nodeName === '#text') {
+      for (const match of tokensIn(node.value)) {
+        const prefix = node.value.slice(0, match.index);
+        violations.push({
+          token: match[0],
+          line: (node.sourceCodeLocation?.startLine ?? 1) + prefix.split('\n').length - 1,
+        });
+      }
+    }
+
+    for (const attribute of node.attrs ?? []) {
+      for (const match of tokensIn(attribute.value)) {
+        violations.push({
+          token: match[0],
+          line: node.sourceCodeLocation?.attrs?.[attribute.name]?.startLine
+            ?? node.sourceCodeLocation?.startLine
+            ?? 1,
+        });
+      }
+    }
+
+    for (const child of node.childNodes ?? []) visit(child);
+  }
+
+  visit(document);
+  return violations;
+}

--- a/scripts/lib/sdk-template-token-lint.mjs
+++ b/scripts/lib/sdk-template-token-lint.mjs
@@ -8,7 +8,7 @@ function preserveLines(match) {
 
 function blankLiquidComments(content) {
   return content.replace(
-    /\{%\s*comment\s*%\}[\s\S]*?\{%\s*endcomment\s*%\}/gi,
+    /\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}/gi,
     preserveLines,
   );
 }

--- a/scripts/lint-sdk.mjs
+++ b/scripts/lint-sdk.mjs
@@ -115,7 +115,7 @@ function pageMatches(filePath) {
 function blankIgnoredMarkup(content) {
   const preserveLines = (match) => '\n'.repeat(match.split('\n').length - 1);
   return content
-    .replace(/\{%\s*comment\s*%\}[\s\S]*?\{%\s*endcomment\s*%\}/g, preserveLines)
+    .replace(/\{%-?\s*comment\s*-?%\}[\s\S]*?\{%-?\s*endcomment\s*-?%\}/g, preserveLines)
     .replace(/<!--[\s\S]*?-->/g, preserveLines);
 }
 
@@ -124,7 +124,8 @@ function lintSource() {
   const families = scopedFamilies();
   for (const fam of families) {
     const dir = join(repoRoot, 'src', fam);
-    for (const file of walk(dir)) {
+    const familyFiles = walk(dir);
+    for (const file of familyFiles) {
       const content = readFileSync(file, 'utf8');
       for (const violation of findLiveSdkTemplateTokens(content)) {
         violations.push({
@@ -135,7 +136,7 @@ function lintSource() {
         });
       }
     }
-    const files = walk(dir).filter((f) => !f.includes('/_includes/') && pageMatches(f));
+    const files = familyFiles.filter((f) => !f.includes('/_includes/') && pageMatches(f));
     for (const file of files) {
       const content = readFileSync(file, 'utf8');
       // Strip Liquid/HTML comments so reference-block notes don't trip the linter.

--- a/scripts/lint-sdk.mjs
+++ b/scripts/lint-sdk.mjs
@@ -26,6 +26,7 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { findLiveSdkTemplateTokens } from './lib/sdk-template-token-lint.mjs';
 
 const repoRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const args = new Set(process.argv.slice(2));
@@ -123,6 +124,17 @@ function lintSource() {
   const families = scopedFamilies();
   for (const fam of families) {
     const dir = join(repoRoot, 'src', fam);
+    for (const file of walk(dir)) {
+      const content = readFileSync(file, 'utf8');
+      for (const violation of findLiveSdkTemplateTokens(content)) {
+        violations.push({
+          kind: 'live-sdk-template-token',
+          file: relative(repoRoot, file),
+          line: violation.line,
+          token: violation.token,
+        });
+      }
+    }
     const files = walk(dir).filter((f) => !f.includes('/_includes/') && pageMatches(f));
     for (const file of files) {
       const content = readFileSync(file, 'utf8');
@@ -252,6 +264,9 @@ function lineOf(content, charIdx) {
 }
 
 function fmt(v) {
+  if (v.kind === 'live-sdk-template-token') {
+    return `  ${v.file}:${v.line}\n    SDK token [${v.token}] can paint before hydration\n    required:  move the token into a real <template> fragment`;
+  }
   if (v.kind === 'inlined-sdk-root') {
     return `  ${v.file}:${v.line}\n    SDK attr [${v.attr}] inlined in page template\n    suggested: ${v.suggestion}\n    snippet:   ${v.snippet}`;
   }
@@ -262,7 +277,9 @@ const all = [];
 if (wantSource) {
   console.log(`[lint-sdk] mode=source  scope=${scope}`);
   const v = lintSource();
-  if (v.length === 0) console.log('  ✓ no inlined SDK roots in page templates\n');
+  if (v.length === 0) {
+    console.log('  ✓ no inlined SDK roots or live pre-hydration template tokens\n');
+  }
   else {
     console.log(`  ✗ ${v.length} violation(s):`);
     for (const it of v) console.log(fmt(it));
@@ -293,6 +310,8 @@ console.log('');
 console.log('Background: v0 catalog requires SDK markup to live in canonical partials');
 console.log('under family _includes/, called via {% campaign_include %}. Inlined SDK');
 console.log('attributes break the agentic build assumption that partials own SDK contracts.');
+console.log('SDK template tokens outside real <template> fragments can also paint literally');
+console.log('before cart hydration, so the source gate rejects them.');
 console.log('See: next-campaigns-ops/docs/checkout-components-inventory-2026-05-01.md');
 
 if (isCI) process.exit(1);

--- a/scripts/sdk-template-token-lint.test.mjs
+++ b/scripts/sdk-template-token-lint.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findLiveSdkTemplateTokens } from './lib/sdk-template-token-lint.mjs';
+
+test('flags SDK template tokens that can paint in the live DOM', () => {
+  assert.deepEqual(
+    findLiveSdkTemplateTokens([
+      '<div>{item.price}</div>',
+      '<span>{total}</span>',
+    ].join('\n')),
+    [
+      { token: '{item.price}', line: 1 },
+      { token: '{total}', line: 2 },
+    ],
+  );
+});
+
+test('allows SDK tokens inside inert template fragments, including nested templates', () => {
+  const source = [
+    '<div data-next-cart-summary>',
+    '  <template>',
+    '    <div>{total}</div>',
+    '    <div data-summary-lines>',
+    '      <template><span>{item.price}</span></template>',
+    '    </div>',
+    '  </template>',
+    '</div>',
+  ].join('\n');
+
+  assert.deepEqual(findLiveSdkTemplateTokens(source), []);
+});
+
+test('ignores documentation tokens in Liquid and HTML comments', () => {
+  const source = [
+    '{% comment %}{item.price}{% endcomment %}',
+    '<!-- {total} -->',
+    '<div>{{ liquid_value }}</div>',
+  ].join('\n');
+
+  assert.deepEqual(findLiveSdkTemplateTokens(source), []);
+});
+
+test('ignores non-rendered script and style text', () => {
+  const source = [
+    '<script>const example = "{item.price}";</script>',
+    '<style>.example::after { content: "{total}"; }</style>',
+  ].join('\n');
+
+  assert.deepEqual(findLiveSdkTemplateTokens(source), []);
+});
+
+test('does not let template-like text inside scripts hide a later live token', () => {
+  const source = [
+    '<script>const example = "<template>{item.price}";</script>',
+    '<div>{item.price}</div>',
+  ].join('\n');
+
+  assert.deepEqual(
+    findLiveSdkTemplateTokens(source),
+    [{ token: '{item.price}', line: 2 }],
+  );
+});
+
+test('resumes enforcement after a template closes and preserves line numbers', () => {
+  const source = [
+    '<template>{item.price}</template>',
+    '<div>',
+    '  {shipping}',
+    '</div>',
+  ].join('\n');
+
+  assert.deepEqual(
+    findLiveSdkTemplateTokens(source),
+    [{ token: '{shipping}', line: 3 }],
+  );
+});

--- a/scripts/sdk-template-token-lint.test.mjs
+++ b/scripts/sdk-template-token-lint.test.mjs
@@ -34,11 +34,28 @@ test('allows SDK tokens inside inert template fragments, including nested templa
 test('ignores documentation tokens in Liquid and HTML comments', () => {
   const source = [
     '{% comment %}{item.price}{% endcomment %}',
+    '{%- comment -%}',
+    '  {shipping}',
+    '{%- endcomment -%}',
     '<!-- {total} -->',
     '<div>{{ liquid_value }}</div>',
   ].join('\n');
 
   assert.deepEqual(findLiveSdkTemplateTokens(source), []);
+});
+
+test('resumes enforcement after a whitespace-controlled Liquid comment', () => {
+  const source = [
+    '{%- comment -%}',
+    '  {item.price}',
+    '{%- endcomment -%}',
+    '<div>{total}</div>',
+  ].join('\n');
+
+  assert.deepEqual(
+    findLiveSdkTemplateTokens(source),
+    [{ token: '{total}', line: 4 }],
+  );
 });
 
 test('ignores non-rendered script and style text', () => {


### PR DESCRIPTION
## Summary
- add a parse5-backed source gate that rejects SDK tokens in live text or attributes outside template fragments
- integrate six regression cases into `lint:sdk:ci`
- continue allowing inert template content, comments, scripts, and styles
- declare parse5 directly as a dev dependency

## Root cause
The current starters already prevent token flash through inert templates and synchronous substitution, but no source gate prevented a future change from placing tokens back in the live DOM.

## Impact
Future template changes cannot reintroduce literal SDK-token flashes. This adds no loading delay or UI changes to the already-safe templates.

## Validation
- `npm run build`
- `npm run lint:sdk:ci`
- `npm run lint:next-core`
- `npm run lint:next-logo`
- `npm run lint:shared`
- `npm run lint:agent-contracts`

Closes #121
