### PR TITLE
fix(shop-three-step): CheckoutGuard finds the SDK's scoped checkout store

### DIFF
--- a/src/shop-three-step/assets/js/checkout-shop-three-billing.js
+++ b/src/shop-three-step/assets/js/checkout-shop-three-billing.js
@@ -21,7 +21,7 @@
     if (!storeData) {
       for (var i = 0; i < sessionStorage.length; i++) {
         var key = sessionStorage.key(i);
-        if (key && key.indexOf('next-checkout-store') === 0) {
+        if (key && key.indexOf('next-checkout-store__') === 0) {
           storeData = sessionStorage.getItem(key);
           break;
         }

--- a/src/shop-three-step/assets/js/checkout-shop-three-billing.js
+++ b/src/shop-three-step/assets/js/checkout-shop-three-billing.js
@@ -14,8 +14,19 @@
     return;
   }
   try {
-    // Try to get checkout store from sessionStorage
+    // Try to get checkout store from sessionStorage. SDK 0.4.34+ scopes storage keys
+    // per campaign (e.g. "next-checkout-store__of7f2o"), so fall back to a prefix scan
+    // when the unscoped legacy key is absent.
     var storeData = sessionStorage.getItem('next-checkout-store');
+    if (!storeData) {
+      for (var i = 0; i < sessionStorage.length; i++) {
+        var key = sessionStorage.key(i);
+        if (key && key.indexOf('next-checkout-store') === 0) {
+          storeData = sessionStorage.getItem(key);
+          break;
+        }
+      }
+    }
     // If no store exists, redirect to first step
     if (!storeData) {
       console.warn('[CheckoutGuard] No checkout store found, redirecting to:', redirectUrl);


### PR DESCRIPTION
## Problem

The shop-three-step funnel has been impassable past step 1 on production since the SDK 0.4.34 bump (Aug 11). Clicking "Continue to Shipping" navigates, but the `CheckoutGuard` in `checkout-shop-three-billing.js` (loaded by both `shipping.html` and `billing.html`) reads the checkout store from the hardcoded sessionStorage key `next-checkout-store` — and SDK 0.4.34's per-campaign storage scoping renamed that key with a scope suffix (`next-checkout-store__<scope>`, e.g. `__of7f2o` on the demo). The guard never finds the store, logs `No checkout store found`, and `location.replace()`s back to `/information/` — fast enough to look like step 1 simply refuses to advance.

## Fix

Try the unscoped legacy key first, then prefix-scan sessionStorage for any key starting with `next-checkout-store`. Matches every scope suffix and stays correct if the scoping algorithm changes. This was the only hardcoded SDK storage key in any family's JS (repo-wide sweep; `landing.js`'s countdown key is its own, not the SDK's).

## Verification (built site, real clicks)

- information → shipping → billing completes; guard logs `Access granted` with correct step + form data at steps 2 and 3
- Fresh session with no checkout store still redirects to step 1 (direct-access protection intact)
- `lint:sdk:ci`, `lint:shared`, `lint:next-core` pass

Regression has been live ~6 days — good candidate for prompt merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)