### PR TITLE
Sync campaign-spec fixtures to real-export dialect (campaigns-os #218)

### DIFF
--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -275,13 +275,6 @@
       "campaign.language",
       "funnels[].pages[]"
     ],
-    "exportDialect": [
-      "schema_version is \"4.3\" and global_config.sdk_version pins the SDK.",
-      "Page packages[] use qty plus boolean is_upsell / is_order_bump role flags; there is no role field.",
-      "Offers (page-level and root catalog) are identified by ref_id.",
-      "Every page carries sdk_hints.sdk_page_type (product | checkout | upsell | receipt); type \"thankyou\" maps to sdk_page_type \"receipt\".",
-      "Shipping methods live only in the root shipping_methods[] catalog, never on pages."
-    ],
     "fixtureOnlyConventions": [
       "sdk_hints.template_family names the starter family for the fixture only.",
       "sdk_hints.frontmatter shows the intended starter-template frontmatter mapping.",

--- a/docs/commerce-surface-catalog.json
+++ b/docs/commerce-surface-catalog.json
@@ -267,13 +267,20 @@
   },
   "campaignSpecFixturePolicy": {
     "directory": "docs/fixtures/campaign-specs",
-    "purpose": "Small CampaignSpec-shaped examples for agent contract reasoning. They are not live Campaigns App exports.",
+    "purpose": "Small CampaignSpec-shaped examples for agent contract reasoning, authored in the real Map Builder export dialect (schema_version 4.3). They are not live Campaigns App exports.",
     "requiredShape": [
       "campaign.id",
       "campaign.name",
       "campaign.currency",
       "campaign.language",
       "funnels[].pages[]"
+    ],
+    "exportDialect": [
+      "schema_version is \"4.3\" and global_config.sdk_version pins the SDK.",
+      "Page packages[] use qty plus boolean is_upsell / is_order_bump role flags; there is no role field.",
+      "Offers (page-level and root catalog) are identified by ref_id.",
+      "Every page carries sdk_hints.sdk_page_type (product | checkout | upsell | receipt); type \"thankyou\" maps to sdk_page_type \"receipt\".",
+      "Shipping methods live only in the root shipping_methods[] catalog, never on pages."
     ],
     "fixtureOnlyConventions": [
       "sdk_hints.template_family names the starter family for the fixture only.",

--- a/docs/fixtures/campaign-specs/README.md
+++ b/docs/fixtures/campaign-specs/README.md
@@ -1,6 +1,6 @@
 # CampaignSpec Agent Fixtures
 
-These JSON files are small CampaignSpec-shaped examples for agent reasoning and human review. They are not live Campaigns App exports and should not be used as production campaign data.
+These JSON files are small CampaignSpec-shaped examples for agent reasoning and human review. They follow the real Map Builder export dialect (`schema_version` 4.3) but are not live Campaigns App exports and should not be used as production campaign data.
 
 What they are for:
 
@@ -8,11 +8,17 @@ What they are for:
 - Give agents concrete examples for package refs, shipping refs, upsell vouchers, and receipt contracts.
 - Keep template-family examples separate from readiness validation. These fixtures document the handoff shape; they do not prove a real campaign is launch-ready.
 
-Fixture conventions:
+Fixture conventions (real-export dialect):
 
-- `sdk_hints.template_family` names the intended starter family for the fixture only.
-- `sdk_hints.frontmatter` shows the frontmatter values an agent would write into the template.
+- Specs are stamped `"schema_version": "4.3"` and pin the SDK via `global_config.sdk_version`.
+- Page `packages[]` use `qty` and boolean role flags `is_upsell` / `is_order_bump`. There is no `role` field.
+- Offers — page-level and root catalog — are identified by `ref_id`.
+- Every page carries `sdk_hints.sdk_page_type` (`product` | `checkout` | `upsell` | `receipt`). Pages with `type: "thankyou"` map to `sdk_page_type: "receipt"`.
+- Shipping methods live only in the root `shipping_methods[]` catalog, not on pages.
+- `sdk_hints.template_family` and `sdk_hints.frontmatter` are template-handoff extensions, not part of a live export. `template_family` names the intended starter family for the fixture only; `frontmatter` shows the values an agent would write into the template.
 - Numeric `ref_id` values are illustrative. Replace them from the target Campaigns API.
 - `shipping_methods[].key` mirrors the starter frontmatter vocabulary, such as `standard` and `free`.
+
+These fixtures are synced verbatim into `NextCommerceCo/campaigns-os` (`contracts/fixtures/campaign-specs/`) by its catalog refresh, where they must pass the CampaignSpec v4 schema conformance gate. Keep them in the dialect above or the downstream gate fails.
 
 Run `npm run lint:agent-contracts` after changing these fixtures or `docs/commerce-surface-catalog.json`.

--- a/docs/fixtures/campaign-specs/README.md
+++ b/docs/fixtures/campaign-specs/README.md
@@ -11,9 +11,9 @@ What they are for:
 Fixture conventions (real-export dialect):
 
 - Specs are stamped `"schema_version": "4.3"` and pin the SDK via `global_config.sdk_version`.
-- Page `packages[]` use `qty` and the boolean role flags `is_upsell` / `is_order_bump` (no `role` field).
+- Page `packages[]` use `qty` and the boolean role flags `is_upsell` / `is_order_bump` (mutually exclusive; a package with neither flag is the main product; no `role` field).
 - Offers — page-level and root catalog — are identified by `ref_id`.
-- Every page carries `sdk_hints.sdk_page_type` (`product` | `checkout` | `upsell` | `receipt`). Pages with `type: "thankyou"` map to `sdk_page_type: "receipt"`.
+- Every page carries `sdk_hints.sdk_page_type` (`product` | `checkout` | `upsell` | `receipt`): `presell` and `landing` pages (including variant-selection pages) map to `product`, `thankyou` maps to `receipt`.
 - Shipping methods live only in the root `shipping_methods[]` catalog, not on pages.
 - `sdk_hints.template_family` and `sdk_hints.frontmatter` are template-handoff extensions, not part of a live export. `template_family` names the intended starter family for the fixture only; `frontmatter` shows the values an agent would write into the template.
 - Numeric `ref_id` values are illustrative. Replace them from the target Campaigns API.

--- a/docs/fixtures/campaign-specs/README.md
+++ b/docs/fixtures/campaign-specs/README.md
@@ -11,7 +11,7 @@ What they are for:
 Fixture conventions (real-export dialect):
 
 - Specs are stamped `"schema_version": "4.3"` and pin the SDK via `global_config.sdk_version`.
-- Page `packages[]` use `qty` and boolean role flags `is_upsell` / `is_order_bump`. There is no `role` field.
+- Page `packages[]` use `qty` and the boolean role flags `is_upsell` / `is_order_bump` (no `role` field).
 - Offers — page-level and root catalog — are identified by `ref_id`.
 - Every page carries `sdk_hints.sdk_page_type` (`product` | `checkout` | `upsell` | `receipt`). Pages with `type: "thankyou"` map to `sdk_page_type: "receipt"`.
 - Shipping methods live only in the root `shipping_methods[]` catalog, not on pages.

--- a/docs/fixtures/campaign-specs/apollo-mv-single-step-configurable.json
+++ b/docs/fixtures/campaign-specs/apollo-mv-single-step-configurable.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-apollo-mv-single",
     "name": "Fixture Apollo MV Single Step Configurable",
@@ -36,6 +37,9 @@
     "map_id": "fixture-apollo-mv-single-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,29 +57,23 @@
           "next_page": "upsell-mv.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1,
+              "qty": 1,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2,
+              "qty": 2,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3,
+              "qty": 3,
               "configurable": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "packages.main_package": 10,
@@ -114,7 +112,17 @@
           "template": "src/apollo-mv-single-step/upsell-mv.html",
           "page_url": "/upsell-mv/",
           "next_page": "upsell-bundle-stepper.html",
+          "on_accept": "upsell-bundle-stepper.html",
+          "on_decline": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "ref_id": 10,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 10,
@@ -149,7 +157,17 @@
           "template": "src/apollo-mv-single-step/upsell-bundle-stepper.html",
           "page_url": "/upsell-bundle-stepper/",
           "next_page": "upsell-bundle-tier-pills.html",
+          "on_accept": "upsell-bundle-tier-pills.html",
+          "on_decline": "upsell-bundle-tier-pills.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -168,7 +186,17 @@
           "template": "src/apollo-mv-single-step/upsell-bundle-tier-pills.html",
           "page_url": "/upsell-bundle-tier-pills/",
           "next_page": "upsell-bundle-tier-cards.html",
+          "on_accept": "upsell-bundle-tier-cards.html",
+          "on_decline": "upsell-bundle-tier-cards.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -205,7 +233,17 @@
           "template": "src/apollo-mv-single-step/upsell-bundle-tier-cards.html",
           "page_url": "/upsell-bundle-tier-cards/",
           "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -246,6 +284,7 @@
           "template": "src/apollo-mv-single-step/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "apollo-mv-single-step",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -273,39 +312,87 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "80% off package 10",
+      "type": "offer",
       "code": "UP80TSHIRT",
-      "package_ref_id": 10,
-      "discount_type": "percent",
-      "value": 80,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "80.00",
+        "description": "80% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 10
+        }
       ]
     },
     {
+      "ref_id": "2",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "3",
+      "name": "60% off package 30",
+      "type": "offer",
       "code": "UP60",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 60,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "60.00",
+        "description": "60% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "4",
+      "name": "70% off package 30",
+      "type": "offer",
       "code": "UP70",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 70,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "70.00",
+        "description": "70% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/apollo-tiered-apollo-layout.json
+++ b/docs/fixtures/campaign-specs/apollo-tiered-apollo-layout.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-apollo-tiered",
     "name": "Fixture Apollo Tiered Apollo Layout",
@@ -36,6 +37,9 @@
     "map_id": "fixture-apollo-tiered-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,36 +57,30 @@
           "next_page": "upsell-bundle-stepper.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1
+              "qty": 1
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2
+              "qty": 2
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3
+              "qty": 3
             },
             {
-              "role": "prepurchase_1",
               "ref_id": 17,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             },
             {
-              "role": "prepurchase_2",
               "ref_id": 19,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "apollo",
             "frontmatter": {
               "packages.main_package": 10,
@@ -126,18 +124,19 @@
           "on_decline": "receipt.html",
           "packages": [
             {
-              "role": "upsell",
               "ref_id": 30,
-              "quantity": 1
+              "qty": 1,
+              "is_upsell": true
             }
           ],
           "offers": [
             {
-              "code": "UP50",
-              "package_ref_id": 30
+              "ref_id": "1",
+              "code": "UP50"
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "apollo",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -154,6 +153,7 @@
           "template": "src/apollo/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "apollo",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -181,12 +181,24 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/demeter-editorial-tiered.json
+++ b/docs/fixtures/campaign-specs/demeter-editorial-tiered.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-demeter-editorial",
     "name": "Fixture Demeter Editorial Tiered",
@@ -36,6 +37,9 @@
     "map_id": "fixture-demeter-editorial-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,36 +57,30 @@
           "next_page": "upsell-bundle-stepper.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1
+              "qty": 1
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2
+              "qty": 2
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3
+              "qty": 3
             },
             {
-              "role": "prepurchase_1",
               "ref_id": 17,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             },
             {
-              "role": "prepurchase_2",
               "ref_id": 19,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "demeter",
             "frontmatter": {
               "packages.main_package": 10,
@@ -123,18 +121,19 @@
           "on_decline": "receipt.html",
           "packages": [
             {
-              "role": "upsell",
               "ref_id": 30,
-              "quantity": 1
+              "qty": 1,
+              "is_upsell": true
             }
           ],
           "offers": [
             {
-              "code": "UP50",
-              "package_ref_id": 30
+              "ref_id": "1",
+              "code": "UP50"
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "demeter",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -151,6 +150,7 @@
           "template": "src/demeter/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "demeter",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -178,12 +178,24 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json
+++ b/docs/fixtures/campaign-specs/olympus-mv-single-step-configurable.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-olympus-mv-single",
     "name": "Fixture Olympus MV Single Step Configurable",
@@ -36,6 +37,9 @@
     "map_id": "fixture-olympus-mv-single-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,29 +57,23 @@
           "next_page": "upsell-mv.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1,
+              "qty": 1,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2,
+              "qty": 2,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3,
+              "qty": 3,
               "configurable": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "packages.main_package": 10,
@@ -110,7 +108,17 @@
           "template": "src/olympus-mv-single-step/upsell-mv.html",
           "page_url": "/upsell-mv/",
           "next_page": "upsell-bundle-stepper.html",
+          "on_accept": "upsell-bundle-stepper.html",
+          "on_decline": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "ref_id": 10,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 10,
@@ -145,7 +153,17 @@
           "template": "src/olympus-mv-single-step/upsell-bundle-stepper.html",
           "page_url": "/upsell-bundle-stepper/",
           "next_page": "upsell-bundle-tier-pills.html",
+          "on_accept": "upsell-bundle-tier-pills.html",
+          "on_decline": "upsell-bundle-tier-pills.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -164,7 +182,17 @@
           "template": "src/olympus-mv-single-step/upsell-bundle-tier-pills.html",
           "page_url": "/upsell-bundle-tier-pills/",
           "next_page": "upsell-bundle-tier-cards.html",
+          "on_accept": "upsell-bundle-tier-cards.html",
+          "on_decline": "upsell-bundle-tier-cards.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -201,7 +229,17 @@
           "template": "src/olympus-mv-single-step/upsell-bundle-tier-cards.html",
           "page_url": "/upsell-bundle-tier-cards/",
           "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -242,6 +280,7 @@
           "template": "src/olympus-mv-single-step/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "olympus-mv-single-step",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -269,39 +308,87 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "80% off package 10",
+      "type": "offer",
       "code": "UP80TSHIRT",
-      "package_ref_id": 10,
-      "discount_type": "percent",
-      "value": 80,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "80.00",
+        "description": "80% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 10
+        }
       ]
     },
     {
+      "ref_id": "2",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "3",
+      "name": "60% off package 30",
+      "type": "offer",
       "code": "UP60",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 60,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "60.00",
+        "description": "60% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "4",
+      "name": "70% off package 30",
+      "type": "offer",
       "code": "UP70",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 70,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "70.00",
+        "description": "70% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json
+++ b/docs/fixtures/campaign-specs/olympus-mv-two-step-configurable.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-olympus-mv-two",
     "name": "Fixture Olympus MV Two Step Configurable",
@@ -36,6 +37,9 @@
     "map_id": "fixture-olympus-mv-two-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -45,7 +49,7 @@
       "pages": [
         {
           "id": "select",
-          "type": "product",
+          "type": "landing",
           "order": 1,
           "label": "Select bundle and variants",
           "template": "src/olympus-mv-two-step/select.html",
@@ -53,29 +57,23 @@
           "next_page": "checkout.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1,
+              "qty": 1,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2,
+              "qty": 2,
               "configurable": true
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3,
+              "qty": 3,
               "configurable": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "product",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "packages.main_package": 10,
@@ -112,6 +110,7 @@
           "page_url": "/checkout/",
           "next_page": "upsell-mv.html",
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "checkout_step.selector_id": "main"
@@ -126,7 +125,17 @@
           "template": "src/olympus-mv-two-step/upsell-mv.html",
           "page_url": "/upsell-mv/",
           "next_page": "upsell-bundle-stepper.html",
+          "on_accept": "upsell-bundle-stepper.html",
+          "on_decline": "upsell-bundle-stepper.html",
+          "packages": [
+            {
+              "ref_id": 10,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "upsell_offer.package_id": 10,
@@ -161,7 +170,17 @@
           "template": "src/olympus-mv-two-step/upsell-bundle-stepper.html",
           "page_url": "/upsell-bundle-stepper/",
           "next_page": "upsell-bundle-tier-pills.html",
+          "on_accept": "upsell-bundle-tier-pills.html",
+          "on_decline": "upsell-bundle-tier-pills.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -180,7 +199,17 @@
           "template": "src/olympus-mv-two-step/upsell-bundle-tier-pills.html",
           "page_url": "/upsell-bundle-tier-pills/",
           "next_page": "upsell-bundle-tier-cards.html",
+          "on_accept": "upsell-bundle-tier-cards.html",
+          "on_decline": "upsell-bundle-tier-cards.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -217,7 +246,17 @@
           "template": "src/olympus-mv-two-step/upsell-bundle-tier-cards.html",
           "page_url": "/upsell-bundle-tier-cards/",
           "next_page": "receipt.html",
+          "on_accept": "receipt.html",
+          "on_decline": "receipt.html",
+          "packages": [
+            {
+              "ref_id": 30,
+              "qty": 1,
+              "is_upsell": true
+            }
+          ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -258,6 +297,7 @@
           "template": "src/olympus-mv-two-step/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "olympus-mv-two-step",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -285,39 +325,87 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "80% off package 10",
+      "type": "offer",
       "code": "UP80TSHIRT",
-      "package_ref_id": 10,
-      "discount_type": "percent",
-      "value": 80,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "80.00",
+        "description": "80% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 10
+        }
       ]
     },
     {
+      "ref_id": "2",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "3",
+      "name": "60% off package 30",
+      "type": "offer",
       "code": "UP60",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 60,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "60.00",
+        "description": "60% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     },
     {
+      "ref_id": "4",
+      "name": "70% off package 30",
+      "type": "offer",
       "code": "UP70",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 70,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "70.00",
+        "description": "70% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/olympus-tiered-standard-free.json
+++ b/docs/fixtures/campaign-specs/olympus-tiered-standard-free.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-olympus-tiered",
     "name": "Fixture Olympus Tiered Standard Free",
@@ -36,6 +37,9 @@
     "map_id": "fixture-olympus-tiered-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,36 +57,30 @@
           "next_page": "upsell-bundle-stepper.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1
+              "qty": 1
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 2
+              "qty": 2
             },
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 3
+              "qty": 3
             },
             {
-              "role": "prepurchase_1",
               "ref_id": 17,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             },
             {
-              "role": "prepurchase_2",
               "ref_id": 19,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "olympus",
             "frontmatter": {
               "packages.main_package": 10,
@@ -122,18 +120,19 @@
           "on_decline": "receipt.html",
           "packages": [
             {
-              "role": "upsell",
               "ref_id": 30,
-              "quantity": 1
+              "qty": 1,
+              "is_upsell": true
             }
           ],
           "offers": [
             {
-              "code": "UP50",
-              "package_ref_id": 30
+              "ref_id": "1",
+              "code": "UP50"
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "olympus",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -150,6 +149,7 @@
           "template": "src/olympus/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "olympus",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -177,12 +177,24 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json
+++ b/docs/fixtures/campaign-specs/shop-single-step-upsell-receipt.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-shop-single-step",
     "name": "Fixture Shop Single Step Upsell Receipt",
@@ -36,6 +37,9 @@
     "map_id": "fixture-shop-single-step-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,21 +57,17 @@
           "next_page": "upsell-bundle-stepper.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1
+              "qty": 1
             },
             {
-              "role": "order_bump",
               "ref_id": 17,
-              "quantity": 1
+              "qty": 1,
+              "is_order_bump": true
             }
           ],
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "shop-single-step",
             "frontmatter": {
               "payment_flags.show_paypal": true,
@@ -89,18 +89,19 @@
           "on_decline": "receipt.html",
           "packages": [
             {
-              "role": "upsell",
               "ref_id": 30,
-              "quantity": 1
+              "qty": 1,
+              "is_upsell": true
             }
           ],
           "offers": [
             {
-              "code": "UP50",
-              "package_ref_id": 30
+              "ref_id": "1",
+              "code": "UP50"
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "shop-single-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -117,6 +118,7 @@
           "template": "src/shop-single-step/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "shop-single-step",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -144,12 +146,24 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]

--- a/docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json
+++ b/docs/fixtures/campaign-specs/shop-three-step-dynamic-shipping.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": "4.3",
   "campaign": {
     "id": "fixture-shop-three-step",
     "name": "Fixture Shop Three Step Dynamic Shipping",
@@ -36,6 +37,9 @@
     "map_id": "fixture-shop-three-step-map",
     "source": "campaign-cart-starter-templates agent fixture"
   },
+  "global_config": {
+    "sdk_version": "0.4.37"
+  },
   "funnels": [
     {
       "id": "default",
@@ -53,12 +57,12 @@
           "next_page": "shipping.html",
           "packages": [
             {
-              "role": "main",
               "ref_id": 10,
-              "quantity": 1
+              "qty": 1
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "shop-three-step",
             "frontmatter": {
               "next_url": "shipping.html"
@@ -73,11 +77,8 @@
           "template": "src/shop-three-step/shipping.html",
           "page_url": "/shipping/",
           "next_page": "billing.html",
-          "shipping_methods": [
-            "standard",
-            "free"
-          ],
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "shop-three-step",
             "frontmatter": {
               "next_url": "billing.html",
@@ -94,6 +95,7 @@
           "page_url": "/billing/",
           "next_page": "upsell-bundle-stepper.html",
           "sdk_hints": {
+            "sdk_page_type": "checkout",
             "template_family": "shop-three-step",
             "frontmatter": {
               "next_url": "upsell-bundle-stepper.html"
@@ -112,18 +114,19 @@
           "on_decline": "receipt.html",
           "packages": [
             {
-              "role": "upsell",
               "ref_id": 30,
-              "quantity": 1
+              "qty": 1,
+              "is_upsell": true
             }
           ],
           "offers": [
             {
-              "code": "UP50",
-              "package_ref_id": 30
+              "ref_id": "1",
+              "code": "UP50"
             }
           ],
           "sdk_hints": {
+            "sdk_page_type": "upsell",
             "template_family": "shop-three-step",
             "frontmatter": {
               "upsell_offer.package_id": 30,
@@ -140,6 +143,7 @@
           "template": "src/shop-three-step/receipt.html",
           "page_url": "/receipt/",
           "sdk_hints": {
+            "sdk_page_type": "receipt",
             "template_family": "shop-three-step",
             "frontmatter": {
               "receipt_summary.title": "Order Summary",
@@ -167,12 +171,24 @@
   ],
   "offers": [
     {
+      "ref_id": "1",
+      "name": "50% off package 30",
+      "type": "offer",
       "code": "UP50",
-      "package_ref_id": 30,
-      "discount_type": "percent",
-      "value": 50,
-      "applies_to": [
-        "upsell"
+      "condition": {
+        "type": "any",
+        "value": null,
+        "description": "No minimum purchase requirement"
+      },
+      "benefit": {
+        "type": "package_percentage",
+        "value": "50.00",
+        "description": "50% off selected packages"
+      },
+      "packages": [
+        {
+          "package_id": 30
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Why

campaigns-os just merged NextCommerceCo/campaigns-os#218 (main = `5c8a561`), which re-authored its vendored copies of these 8 fixtures from the old fixture dialect into the real Map Builder export dialect. The campaigns-os catalog refresh (`scripts/refresh-starter-template-catalog.mjs`, triggered by this repo's `dispatch-campaigns-os-catalog-refresh` workflow) copies `docs/fixtures/campaign-specs/*` from this repo **verbatim**. Without this upstream sync, the next refresh would revert all 8 fixtures to the old dialect and trip the campaigns-os CampaignSpec v4 schema conformance gate.

## What changed

The 8 fixture files are byte-for-byte copies of campaigns-os@`5c8a561` `contracts/fixtures/campaign-specs/`. Dialect conversions:

- Stamped `"schema_version": "4.3"` and `global_config: { "sdk_version": "0.4.37" }` (replaces `runtime.sdk_version`)
- Page `packages[]` use `qty` (not `quantity`) and boolean role flags `is_upsell` / `is_order_bump` (no `role` field)
- Offers — page-level and root catalog — are identified by `ref_id` (not `package_ref_id`)
- Every page carries `sdk_hints.sdk_page_type` (`product` / `checkout` / `upsell` / `receipt`); `type: "thankyou"` pages map to `sdk_page_type: "receipt"`
- Page-level `shipping_methods` arrays dropped; shipping lives only in the root `shipping_methods[]` catalog
- `sdk_hints.frontmatter` and `sdk_hints.template_family` kept — blessed template-handoff extensions
- Semantic fix: the olympus-mv-two-step "select" page changed `type: "product"` → `type: "landing"` with `sdk_page_type: "product"`

Docs: `docs/fixtures/campaign-specs/README.md` documents the export dialect (single home for the conventions); the catalog's `campaignSpecFixturePolicy` purpose line points at it. No lint or script here referenced the old dialect — `lint-agent-contracts.mjs` validates dialect-neutral shape and passes unchanged.

## Round-trip proof

Simulated the campaigns-os refresh fixture loop exactly — same fixture set from the catalog (`collectSourceFixturePaths`), the real `mapTemplateSnapshotPath` imported from the campaigns-os script, and its trailing-newline normalization — reading from this branch instead of the GitHub API, then byte-compared against campaigns-os@`5c8a561`:

```
8 fixtures checked, 0 would change on refresh
```

i.e. a catalog refresh from this branch reproduces campaigns-os main's fixtures byte-for-byte (fixture no-op).

## Checks

Ran the full `lint-sdk` CI sequence locally, all green: `lint:next-core`, `lint:next-logo`, `lint:shared`, `test:template-verification`, `validate:template-verification`, `npm run build` (66 pages), `lint:sdk:ci`, plus `lint:agent-contracts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
